### PR TITLE
Add HotKeys for Pointer tools and Menu Options

### DIFF
--- a/Scribble/Tools/PointerTools/ArrowTool/ArrowTool.cs
+++ b/Scribble/Tools/PointerTools/ArrowTool/ArrowTool.cs
@@ -32,6 +32,7 @@ public class ArrowTool : StrokeTool
         _startPoint = null;
 
         HotKey = new KeyGesture(Key.D5);
+        ToolTip = "Arrow Tool - 5";
     }
 
     public override void HandlePointerClick(Point coord)

--- a/Scribble/Tools/PointerTools/EllipseTool/EllipseTool.cs
+++ b/Scribble/Tools/PointerTools/EllipseTool/EllipseTool.cs
@@ -36,6 +36,7 @@ public class EllipseTool : StrokeTool
         _startPoint = null;
 
         HotKey = new KeyGesture(Key.D6);
+        ToolTip = "Ellipse Tool - 6";
     }
 
     public override void HandlePointerClick(Point coord)

--- a/Scribble/Tools/PointerTools/EraseTool/EraseTool.cs
+++ b/Scribble/Tools/PointerTools/EraseTool/EraseTool.cs
@@ -18,6 +18,7 @@ public class EraseTool : PointerTool
         Cursor = new Cursor(ToolIcon.CreateScaledBitmap(new PixelSize(36, 36)), new PixelPoint(10, 30));
 
         HotKey = new KeyGesture(Key.D2);
+        ToolTip = "Erase Tool - 2";
     }
 
     public override void HandlePointerClick(Point coord)

--- a/Scribble/Tools/PointerTools/LineTool/LineTool.cs
+++ b/Scribble/Tools/PointerTools/LineTool/LineTool.cs
@@ -32,6 +32,7 @@ public class LineTool : StrokeTool
         _startPoint = null;
 
         HotKey = new KeyGesture(Key.D4);
+        ToolTip = "Line Tool - 4";
     }
 
     public override void HandlePointerClick(Point coord)

--- a/Scribble/Tools/PointerTools/PanningTool/PanningTool.cs
+++ b/Scribble/Tools/PointerTools/PanningTool/PanningTool.cs
@@ -16,6 +16,7 @@ public class PanningTool : PointerTool
         Cursor = new Cursor(ToolIcon.CreateScaledBitmap(new PixelSize(30, 30)), new PixelPoint(15, 15));
 
         HotKey = new KeyGesture(Key.D3);
+        ToolTip = "Panning Tool - 3";
     }
 
     public override void HandlePointerMove(Point prevCoord, Point currentCoord)

--- a/Scribble/Tools/PointerTools/PencilTool/PencilTool.cs
+++ b/Scribble/Tools/PointerTools/PencilTool/PencilTool.cs
@@ -27,6 +27,7 @@ public class PencilTool : StrokeTool
         };
 
         HotKey = new KeyGesture(Key.D1);
+        ToolTip = "Pencil Tool - 1";
     }
 
     public override void HandlePointerClick(Point coord)

--- a/Scribble/Tools/PointerTools/PointerTool.cs
+++ b/Scribble/Tools/PointerTools/PointerTool.cs
@@ -20,6 +20,7 @@ public abstract class PointerTool(string name, MainViewModel viewModel, Bitmap i
     public readonly Bitmap ToolIcon = icon;
     public Cursor? Cursor;
     public KeyGesture? HotKey { get; protected init; }
+    public string ToolTip { get; protected init; } = name;
 
     /// <summary>
     /// Loads a bitmap relative to the tool's folder.

--- a/Scribble/Tools/PointerTools/RectangleTool/RectangleTool.cs
+++ b/Scribble/Tools/PointerTools/RectangleTool/RectangleTool.cs
@@ -36,6 +36,7 @@ public class RectangleTool : StrokeTool
         _startPoint = null;
 
         HotKey = new KeyGesture(Key.D7);
+        ToolTip = "Rectangle Tool - 7";
     }
 
     public override void HandlePointerClick(Point coord)

--- a/Scribble/Tools/PointerTools/SelectTool/SelectTool.cs
+++ b/Scribble/Tools/PointerTools/SelectTool/SelectTool.cs
@@ -25,6 +25,7 @@ class SelectTool : PointerTool
         _canvasContainer = canvasContainer;
 
         HotKey = new KeyGesture(Key.D9);
+        ToolTip = "Select Tool - 9";
     }
 
     public override void HandlePointerClick(Point coord)

--- a/Scribble/Tools/PointerTools/TextTool/TextTool.cs
+++ b/Scribble/Tools/PointerTools/TextTool/TextTool.cs
@@ -35,6 +35,7 @@ public class TextTool : StrokeTool
         };
 
         HotKey = new KeyGesture(Key.D8);
+        ToolTip = "Text Tool - 8";
     }
 
     public override void HandlePointerClick(Point coord)

--- a/Scribble/Views/MainView.axaml
+++ b/Scribble/Views/MainView.axaml
@@ -124,14 +124,14 @@
                         IsVisible="False">
                     <StackPanel Spacing="4">
                         <Button Name="OpenFileMenuOption" HorizontalAlignment="Stretch"
-                                Click="OpenFileMenuOption_OnClick" HotKey="Ctrl+O">
+                                Click="OpenFileMenuOption_OnClick" HotKey="Ctrl+O" ToolTip.Tip="Ctrl+O">
                             <StackPanel Orientation="Horizontal" Spacing="4">
                                 <Image Source="avares://Scribble/Assets/open.png" Width="18" Height="18" />
                                 <Label FontSize="12">Open...</Label>
                             </StackPanel>
                         </Button>
                         <Button Name="SaveToFileMenuOption" Margin="0" Click="SaveToFileMenuOption_OnClick"
-                                HorizontalAlignment="Stretch" HotKey="Ctrl+S">
+                                HorizontalAlignment="Stretch" HotKey="Ctrl+S" ToolTip.Tip="Ctrl+S">
                             <StackPanel Orientation="Horizontal" Spacing="4">
                                 <Image Source="avares://Scribble/Assets/save.png" Width="18" Height="18" />
                                 <Label FontSize="12">Save to file</Label>
@@ -139,7 +139,7 @@
                         </Button>
                         <Button Name="ResetCanvasMenuOption" Margin="0" Click="ResetCanvasMenuOption_OnClick"
                                 IsVisible="{Binding CanResetCanvas}"
-                                HorizontalAlignment="Stretch" HotKey="Ctrl+R">
+                                HorizontalAlignment="Stretch" HotKey="Ctrl+R" ToolTip.Tip="Ctrl+R">
                             <StackPanel Orientation="Horizontal" Spacing="4">
                                 <Image Source="avares://Scribble/Assets/bin.png" Width="18" Height="18" />
                                 <Label FontSize="12">Reset canvas</Label>
@@ -153,7 +153,7 @@
                             </StackPanel>
                         </Button>
                         <Button Name="ExitOption" Margin="0" Click="ExitOption_OnClick" HorizontalAlignment="Stretch"
-                                HotKey="Ctrl+X">
+                                HotKey="Ctrl+X" ToolTip.Tip="Ctrl+X">
                             <StackPanel Orientation="Horizontal" Spacing="4">
                                 <Image Source="avares://Scribble/Assets/exit.png" Width="18" Height="18" />
                                 <Label FontSize="12">Exit</Label>
@@ -192,7 +192,8 @@
                 Padding="8"
                 BoxShadow="0 4 20 0 #60000000">
                 <Panel>
-                    <Button Name="LiveDrawingButton" Click="LiveDrawingButton_OnClick">
+                    <Button Name="LiveDrawingButton" Click="LiveDrawingButton_OnClick"
+                            ToolTip.Tip="Collaborative Drawing">
                         <Image Margin="4" Source="avares://Scribble/Assets/group.png" />
                     </Button>
                     <Border

--- a/Scribble/Views/MainView.axaml.cs
+++ b/Scribble/Views/MainView.axaml.cs
@@ -113,11 +113,13 @@ public partial class MainView : UserControl
         };
         ToggleButtonGroup.SetGroupName(toggleButton, "PointerTools");
 
+        ToolTip.SetTip(toggleButton, tool.ToolTip);
         // Connect the tool's hotkey
         if (tool.HotKey != null)
         {
             toggleButton.HotKey = tool.HotKey;
         }
+
 
         toggleButton.IsCheckedChanged += (object? sender, RoutedEventArgs e) =>
         {


### PR DESCRIPTION
This pull request adds keyboard shortcuts (hotkeys) and tooltips to various pointer tools and menu actions in the Scribble app, improving accessibility and usability. Each tool is now associated with a unique hotkey and a corresponding tooltip, and menu buttons also display their shortcuts. The registration of pointer tools has been updated to support these enhancements.

**Pointer Tool Enhancements:**

* Added `HotKey` and `ToolTip` properties to the `PointerTool` base class, allowing all tools to specify a keyboard shortcut and tooltip. (`Scribble/Tools/PointerTools/PointerTool.cs`)
* Assigned unique hotkeys and descriptive tooltips to each pointer tool (Pencil, Erase, Panning, Line, Arrow, Ellipse, Rectangle, Text, Select) for quick tool switching

**Menu and UI Improvements:**

* Added hotkeys and tooltips to main menu buttons (Open, Save, Reset Canvas, Exit) and the collaborative drawing button, making shortcuts visible and accessible to users

**Tool Registration Update:**

* Modified the pointer tool registration logic to set the tooltip and hotkey on toggle buttons, ensuring the UI reflects the new properties and shortcuts work as intended. (`Scribble/Views/MainView.axaml.cs`)