### PR TITLE
Smoothen pencil drawing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -489,3 +489,4 @@ out
 Directory.Build.props
 
 docs
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -487,3 +487,5 @@ staging
 out
 
 Directory.Build.props
+
+docs

--- a/Scribble.Shared/Lib/CanvasElements/Strokes/DrawStroke.cs
+++ b/Scribble.Shared/Lib/CanvasElements/Strokes/DrawStroke.cs
@@ -9,4 +9,9 @@ public class DrawStroke : PaintableStroke
     /// The Tool that produced the stroke
     /// </summary>
     public required ToolType ToolType;
+
+    /// <summary>
+    /// The raw input points that build up the stroke
+    /// </summary>
+    public List<StrokePoint> RawPoints { get; init; } = [];
 }

--- a/Scribble.Shared/Lib/CanvasElements/Strokes/DrawStroke.cs
+++ b/Scribble.Shared/Lib/CanvasElements/Strokes/DrawStroke.cs
@@ -13,5 +13,6 @@ public class DrawStroke : PaintableStroke
     /// <summary>
     /// The raw input points that build up the stroke
     /// </summary>
+    [System.Text.Json.Serialization.JsonIgnore]
     public List<StrokePoint> RawPoints { get; init; } = [];
 }

--- a/Scribble.Shared/Lib/CanvasElements/Strokes/StrokePoint.cs
+++ b/Scribble.Shared/Lib/CanvasElements/Strokes/StrokePoint.cs
@@ -1,0 +1,8 @@
+using SkiaSharp;
+
+namespace Scribble.Shared.Lib.CanvasElements.Strokes;
+
+/// <summary>
+/// Represents a single point in a stroke
+/// </summary>
+public record struct StrokePoint(SKPoint Point, long TimestampMs);

--- a/Scribble/Services/CanvasStateService.cs
+++ b/Scribble/Services/CanvasStateService.cs
@@ -171,9 +171,13 @@ public class CanvasStateService
         // apply directly to the existing stroke — no replay needed
         if (@event is PencilStrokeLineToEvent pencilLineToEvent)
         {
-            if (_strokeLookup.TryGetValue(pencilLineToEvent.StrokeId, out var stroke))
+            if (_strokeLookup.TryGetValue(pencilLineToEvent.StrokeId, out var stroke) && stroke is DrawStroke ds)
             {
-                stroke.Path.LineTo(pencilLineToEvent.Point);
+                ds.RawPoints.Add(new StrokePoint(pencilLineToEvent.Point, pencilLineToEvent.TimeStamp.Ticks / TimeSpan.TicksPerMillisecond));
+                var newPath = FreehandPathBuilder.Build(ds.RawPoints);
+                ds.Path.Reset();
+                ds.Path.AddPath(newPath);
+
                 CanvasInvalidated?.Invoke();
                 return;
             }
@@ -424,6 +428,7 @@ public class CanvasStateService
                         Id = ev.StrokeId,
                         Paint = ev.StrokePaint.Clone(),
                         Path = newLinePath,
+                        RawPoints = [new StrokePoint(ev.StartPoint, ev.TimeStamp.Ticks / TimeSpan.TicksPerMillisecond)],
                         ToolType = ev.ToolType,
                         ToolOptions = ev.ToolOptions,
                         CreatorConnectionId = ev.CreatorConnectionId,
@@ -493,9 +498,12 @@ public class CanvasStateService
 
                     break;
                 case PencilStrokeLineToEvent ev:
-                    if (paintableStrokes.ContainsKey(ev.StrokeId))
+                    if (paintableStrokes.TryGetValue(ev.StrokeId, out var pStroke) && pStroke is DrawStroke dsPencil)
                     {
-                        paintableStrokes[ev.StrokeId].Path.LineTo(ev.Point);
+                        dsPencil.RawPoints.Add(new StrokePoint(ev.Point, ev.TimeStamp.Ticks / TimeSpan.TicksPerMillisecond));
+                        var newPath = FreehandPathBuilder.Build(dsPencil.RawPoints);
+                        dsPencil.Path.Reset();
+                        dsPencil.Path.AddPath(newPath);
                     }
 
                     break;
@@ -716,6 +724,7 @@ public class CanvasStateService
                                 ToolOptions = drawStroke.ToolOptions,
                                 ToolType = drawStroke.ToolType,
                                 Path = drawStroke.Path.Clone(),
+                                RawPoints = [..drawStroke.RawPoints],
                                 LayerIndex = drawStroke.LayerIndex,
                                 CreatorConnectionId = drawStroke.CreatorConnectionId
                             };

--- a/Scribble/Tools/PointerTools/PencilTool/PencilTool.cs
+++ b/Scribble/Tools/PointerTools/PencilTool/PencilTool.cs
@@ -11,6 +11,8 @@ public class PencilTool : StrokeTool
 {
     private Guid _strokeId = Guid.NewGuid();
     private Guid _actionId = Guid.NewGuid();
+    private SKPoint _lastAcceptedPoint;
+    private const float DistanceThreshold = 2.0f;
 
     public PencilTool(string name, CanvasStateService canvasState) : base(name, canvasState,
         LoadToolBitmap(typeof(PencilTool), "pencil.png"))
@@ -26,6 +28,7 @@ public class PencilTool : StrokeTool
         var startPoint = new SKPoint((float)coord.X, (float)coord.Y);
         _strokeId = Guid.NewGuid();
         _actionId = Guid.NewGuid();
+        _lastAcceptedPoint = startPoint;
         CanvasState.ApplyEvent(
             new StartStrokeEvent(_actionId, _strokeId, startPoint, StrokePaint.Clone(), ToolType.Pencil, ToolOptions));
     }
@@ -33,6 +36,15 @@ public class PencilTool : StrokeTool
     public override void HandlePointerMove(Point prevCoord, Point currentCoord)
     {
         var nextPoint = new SKPoint((float)currentCoord.X, (float)currentCoord.Y);
+        
+        var distance = SKPoint.Distance(_lastAcceptedPoint, nextPoint);
+        if (distance < DistanceThreshold)
+        {
+            return;
+        }
+
+        _lastAcceptedPoint = nextPoint;
+
         CanvasState.ApplyEvent(new PencilStrokeLineToEvent(_actionId, _strokeId, nextPoint));
     }
 

--- a/Scribble/Utils/FreehandPathBuilder.cs
+++ b/Scribble/Utils/FreehandPathBuilder.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using Scribble.Shared.Lib.CanvasElements.Strokes;
+using SkiaSharp;
+
+namespace Scribble.Utils;
+
+/// <summary>
+/// Builds a smooth path from a list of raw stroke points
+/// </summary>
+public static class FreehandPathBuilder
+{
+    public static SKPath Build(IReadOnlyList<StrokePoint> points)
+    {
+        var path = new SKPath();
+
+        if (points.Count == 0)
+        {
+            return path;
+        }
+
+        if (points.Count == 1)
+        {
+            path.MoveTo(points[0].Point);
+            return path;
+        }
+
+        if (points.Count == 2)
+        {
+            path.MoveTo(points[0].Point);
+            path.LineTo(points[1].Point);
+            return path;
+        }
+
+        path.MoveTo(points[0].Point);
+
+        // Build a smooth path using quadratic beziers
+        for (int i = 1; i < points.Count - 1; i++)
+        {
+            var p0 = points[i].Point;
+            var p1 = points[i + 1].Point;
+            var midPoint = new SKPoint((p0.X + p1.X) / 2f, (p0.Y + p1.Y) / 2f);
+            path.QuadTo(p0.X, p0.Y, midPoint.X, midPoint.Y);
+        }
+
+        path.LineTo(points[^1].Point);
+
+        return path;
+    }
+}


### PR DESCRIPTION
This pull request introduces a new system for tracking and reconstructing freehand pencil strokes by storing the raw input points and rebuilding the stroke path dynamically. It also adds logic to reduce redundant points for performance and smoother drawing. The main changes are grouped into enhancements to stroke data structures, stroke reconstruction logic, and input handling improvements.

**Stroke Data Model Enhancements:**
- Added a new `StrokePoint` struct to represent a point in a stroke, including both position and timestamp (`StrokePoint.cs`).
- Updated `DrawStroke` to store a list of raw input points (`RawPoints`) used to build the stroke (`DrawStroke.cs`).

**Stroke Reconstruction and Rendering:**
- Introduced `FreehandPathBuilder`, a utility for building smooth paths from raw stroke points using quadratic Bezier curves (`FreehandPathBuilder.cs`).
- Modified stroke event processing and replay logic to update and use `RawPoints` for reconstructing paths, ensuring accurate and smooth rendering when events are replayed or strokes are updated (`CanvasStateService.cs`)

**Input Handling and Performance:**
- Updated `PencilTool` to ignore pointer moves that are too close together (less than a threshold distance), reducing unnecessary points and improving performance and stroke quality (`PencilTool.cs`)

Closes #85 