### PR TITLE
Refactor keybindings and fix startup issues

### DIFF
--- a/Scribble/Views/MainView.axaml
+++ b/Scribble/Views/MainView.axaml
@@ -30,7 +30,24 @@
         <!-- Overlay canvas for selection UI and text edit borders (layered on top of SkiaCanvas) -->
         <Canvas Name="CanvasContainer"
                 HorizontalAlignment="Stretch"
-                VerticalAlignment="Stretch">
+                VerticalAlignment="Stretch"
+                Focusable="True">
+            <Canvas.KeyBindings>
+                <!-- Menu Options -->
+                <KeyBinding Gesture="Ctrl+O" Command="{Binding DocumentViewModel.LoadCanvasFromFileActionCommand}" />
+                <KeyBinding Gesture="Ctrl+S" Command="{Binding DocumentViewModel.SaveCanvasToFileActionCommand}" />
+                <KeyBinding Gesture="Ctrl+R" Command="{Binding ResetCanvasCommand}" />
+                <KeyBinding Gesture="Ctrl+X" Command="{Binding ExitCommand}" />
+
+                <!-- Undo/Redo -->
+                <KeyBinding Gesture="Ctrl+Z" Command="{Binding UndoCommand}" />
+                <KeyBinding Gesture="Ctrl+Shift+Z" Command="{Binding RedoCommand}" />
+
+                <!-- Zoom -->
+                <KeyBinding Gesture="Ctrl+OemMinus" Command="{Binding UiStateViewModel.ZoomOutCommand}" />
+                <KeyBinding Gesture="Ctrl+OemPlus" Command="{Binding UiStateViewModel.ZoomInCommand}" />
+            </Canvas.KeyBindings>
+
             <!-- COVERS SELECTED ELEMENTS -->
             <StackPanel Name="SelectionOverlay" Spacing="6" IsVisible="False">
                 <Border Name="SelectionRotationBtn" CornerRadius="100" BorderThickness="2" BorderBrush="Gray"
@@ -120,7 +137,6 @@
                         <Button Name="OpenFileMenuOption" HorizontalAlignment="Stretch"
                                 Command="{Binding DocumentViewModel.LoadCanvasFromFileActionCommand}"
                                 IsVisible="{Binding MultiUserDrawingViewModel.CanResetCanvas}"
-                                HotKey="Ctrl+O"
                                 ToolTip.Tip="Ctrl+O">
                             <StackPanel Orientation="Horizontal" Spacing="4">
                                 <Image Source="avares://Scribble/Assets/open.png" Width="18" Height="18" />
@@ -129,7 +145,7 @@
                         </Button>
                         <Button Name="SaveToFileMenuOption" Margin="0"
                                 Command="{Binding DocumentViewModel.SaveCanvasToFileActionCommand}"
-                                HorizontalAlignment="Stretch" HotKey="Ctrl+S" ToolTip.Tip="Ctrl+S">
+                                HorizontalAlignment="Stretch" ToolTip.Tip="Ctrl+S">
                             <StackPanel Orientation="Horizontal" Spacing="4">
                                 <Image Source="avares://Scribble/Assets/save.png" Width="18" Height="18" />
                                 <Label FontSize="12">Save to file</Label>
@@ -137,7 +153,7 @@
                         </Button>
                         <Button Name="ExportMenuOption" Margin="0"
                                 Click="ExportMenuOption_OnClick"
-                                HorizontalAlignment="Stretch" HotKey="Ctrl+Shift+E" ToolTip.Tip="Ctrl+Shift+E">
+                                HorizontalAlignment="Stretch" ToolTip.Tip="Ctrl+Shift+E">
                             <StackPanel Orientation="Horizontal" Spacing="4">
                                 <Image Source="avares://Scribble/Assets/export.png" Width="18" Height="18" />
                                 <Label FontSize="12">Export to Image</Label>
@@ -146,7 +162,7 @@
                         <Button Name="ResetCanvasMenuOption" Margin="0"
                                 Command="{Binding ResetCanvasCommand}"
                                 IsVisible="{Binding MultiUserDrawingViewModel.CanResetCanvas}"
-                                HorizontalAlignment="Stretch" HotKey="Ctrl+R" ToolTip.Tip="Ctrl+R">
+                                HorizontalAlignment="Stretch" ToolTip.Tip="Ctrl+R">
                             <StackPanel Orientation="Horizontal" Spacing="4">
                                 <Image Source="avares://Scribble/Assets/bin.png" Width="18" Height="18" />
                                 <Label FontSize="12">Reset canvas</Label>
@@ -161,7 +177,7 @@
                         </Button>
                         <Button Name="ExitOption" Margin="0" Command="{Binding ExitCommand}"
                                 HorizontalAlignment="Stretch"
-                                HotKey="Ctrl+X" ToolTip.Tip="Ctrl+X">
+                                ToolTip.Tip="Ctrl+X">
                             <StackPanel Orientation="Horizontal" Spacing="4">
                                 <Image Source="avares://Scribble/Assets/exit.png" Width="18" Height="18" />
                                 <Label FontSize="12">Exit</Label>
@@ -643,14 +659,12 @@
             <StackPanel Orientation="Horizontal">
                 <Button ToolTip.Tip="Undo - Ctrl+Z"
                         Name="UndoButton"
-                        Command="{Binding UndoCommand}"
-                        HotKey="Ctrl+Z">
+                        Command="{Binding UndoCommand}">
                     <Image Source="avares://Scribble/Assets/undo.png" Margin="4" Width="15" Height="15" />
                 </Button>
                 <Button ToolTip.Tip="Redo - Ctrl+Shift+Z"
                         Name="RedoButton"
-                        Command="{Binding RedoCommand}"
-                        HotKey="Ctrl+Shift+Z">
+                        Command="{Binding RedoCommand}">
                     <Image Source="avares://Scribble/Assets/redo.png" Margin="4" Width="15" Height="15" />
                 </Button>
             </StackPanel>
@@ -687,7 +701,6 @@
                 Padding="12, 6"
                 HorizontalAlignment="Stretch"
                 HorizontalContentAlignment="Center"
-                HotKey="Shift+D1"
                 Click="ZoomToFitBtn_OnClick">
                 <TextBlock Text="Zoom to Fit" Foreground="White" FontSize="12" />
             </Button>
@@ -698,16 +711,14 @@
                 <StackPanel Orientation="Horizontal" Spacing="2">
                     <Button ToolTip.Tip="Zoom out - Ctrl + '-'"
                             Name="ZoomOutBtn"
-                            Command="{Binding UiStateViewModel.ZoomOutCommand}"
-                            HotKey="Ctrl+OemMinus">
+                            Command="{Binding UiStateViewModel.ZoomOutCommand}">
                         <Image Source="avares://Scribble/Assets/minus.png" Margin="4" Width="15" Height="15" />
                     </Button>
                     <TextBlock Name="ScaleFactorText" Text="{Binding UiStateViewModel.ScaleFactorText}"
                                VerticalAlignment="Center" />
                     <Button ToolTip.Tip="Zoom in - Ctrl + '+'"
                             Name="ZoomInBtn"
-                            Command="{Binding UiStateViewModel.ZoomInCommand}"
-                            HotKey="Ctrl+OemPlus">
+                            Command="{Binding UiStateViewModel.ZoomInCommand}">
                         <Image Source="avares://Scribble/Assets/plus.png" Margin="4" Width="15" Height="15" />
                     </Button>
                 </StackPanel>

--- a/Scribble/Views/MainView.axaml
+++ b/Scribble/Views/MainView.axaml
@@ -17,10 +17,6 @@
          to set the actual DataContext for runtime, set the DataContext property in code (look at App.axaml.cs) -->
         <vm:MainViewModel />
     </Design.DataContext>
-    <UserControl.KeyBindings>
-        <KeyBinding Gesture="Ctrl+Z" Command="{Binding UndoCommand}" />
-        <KeyBinding Gesture="Ctrl+Shift+Z" Command="{Binding RedoCommand}" />
-    </UserControl.KeyBindings>
     <!-- Infinite canvas: SkiaCanvas fills the viewport, camera transform handles panning/zooming -->
     <Panel>
         <controls:SkiaCanvas Name="MainCanvas"
@@ -645,10 +641,16 @@
                 Background="#2c2c2c"
                 Margin="8,0,0,12">
             <StackPanel Orientation="Horizontal">
-                <Button ToolTip.Tip="Undo - Ctrl+Z" Name="UndoButton" Command="{Binding UndoCommand}">
+                <Button ToolTip.Tip="Undo - Ctrl+Z"
+                        Name="UndoButton"
+                        Command="{Binding UndoCommand}"
+                        HotKey="Ctrl+Z">
                     <Image Source="avares://Scribble/Assets/undo.png" Margin="4" Width="15" Height="15" />
                 </Button>
-                <Button ToolTip.Tip="Redo - Ctrl+Shift+Z" Name="RedoButton" Command="{Binding RedoCommand}">
+                <Button ToolTip.Tip="Redo - Ctrl+Shift+Z"
+                        Name="RedoButton"
+                        Command="{Binding RedoCommand}"
+                        HotKey="Ctrl+Shift+Z">
                     <Image Source="avares://Scribble/Assets/redo.png" Margin="4" Width="15" Height="15" />
                 </Button>
             </StackPanel>
@@ -693,45 +695,45 @@
             <Border
                 CornerRadius="8"
                 Background="#2c2c2c">
-            <StackPanel Orientation="Horizontal" Spacing="2">
-                <Button ToolTip.Tip="Zoom out - Ctrl + '-'"
-                        Name="ZoomOutBtn"
-                        Command="{Binding UiStateViewModel.ZoomOutCommand}"
-                        HotKey="Ctrl+OemMinus">
-                    <Image Source="avares://Scribble/Assets/minus.png" Margin="4" Width="15" Height="15" />
-                </Button>
-                <TextBlock Name="ScaleFactorText" Text="{Binding UiStateViewModel.ScaleFactorText}"
-                           VerticalAlignment="Center" />
-                <Button ToolTip.Tip="Zoom in - Ctrl + '+'"
-                        Name="ZoomInBtn"
-                        Command="{Binding UiStateViewModel.ZoomInCommand}"
-                        HotKey="Ctrl+OemPlus">
-                    <Image Source="avares://Scribble/Assets/plus.png" Margin="4" Width="15" Height="15" />
-                </Button>
-            </StackPanel>
-            <Border.Styles>
-                <Style Selector="Button">
-                    <Setter Property="Background" Value="#2c2c2c" />
-                </Style>
+                <StackPanel Orientation="Horizontal" Spacing="2">
+                    <Button ToolTip.Tip="Zoom out - Ctrl + '-'"
+                            Name="ZoomOutBtn"
+                            Command="{Binding UiStateViewModel.ZoomOutCommand}"
+                            HotKey="Ctrl+OemMinus">
+                        <Image Source="avares://Scribble/Assets/minus.png" Margin="4" Width="15" Height="15" />
+                    </Button>
+                    <TextBlock Name="ScaleFactorText" Text="{Binding UiStateViewModel.ScaleFactorText}"
+                               VerticalAlignment="Center" />
+                    <Button ToolTip.Tip="Zoom in - Ctrl + '+'"
+                            Name="ZoomInBtn"
+                            Command="{Binding UiStateViewModel.ZoomInCommand}"
+                            HotKey="Ctrl+OemPlus">
+                        <Image Source="avares://Scribble/Assets/plus.png" Margin="4" Width="15" Height="15" />
+                    </Button>
+                </StackPanel>
+                <Border.Styles>
+                    <Style Selector="Button">
+                        <Setter Property="Background" Value="#2c2c2c" />
+                    </Style>
 
-                <Style Selector="Button:pointerover /template/ ContentPresenter">
-                    <Setter Property="Background" Value="#3c3c3c" />
-                </Style>
+                    <Style Selector="Button:pointerover /template/ ContentPresenter">
+                        <Setter Property="Background" Value="#3c3c3c" />
+                    </Style>
 
-                <Style Selector="Button:pressed /template/ ContentPresenter">
-                    <Setter Property="Background" Value="#1c1c1c" />
-                </Style>
+                    <Style Selector="Button:pressed /template/ ContentPresenter">
+                        <Setter Property="Background" Value="#1c1c1c" />
+                    </Style>
 
-                <Style Selector="Button:disabled /template/ ContentPresenter">
-                    <Setter Property="Background" Value="#2c2c2c" />
-                </Style>
+                    <Style Selector="Button:disabled /template/ ContentPresenter">
+                        <Setter Property="Background" Value="#2c2c2c" />
+                    </Style>
 
-                <Style Selector="TextBlock">
-                    <Setter Property="Foreground" Value="White" />
-                    <Setter Property="Background" Value="#2c2c2c" />
-                </Style>
-            </Border.Styles>
-        </Border>
+                    <Style Selector="TextBlock">
+                        <Setter Property="Foreground" Value="White" />
+                        <Setter Property="Background" Value="#2c2c2c" />
+                    </Style>
+                </Border.Styles>
+            </Border>
         </StackPanel>
 
         <!-- Export to Image -->

--- a/Scribble/Views/MainView.axaml.cs
+++ b/Scribble/Views/MainView.axaml.cs
@@ -10,6 +10,7 @@ using Avalonia.Media.Imaging;
 using Avalonia.Platform;
 using Avalonia.Skia;
 using Avalonia.Threading;
+using CommunityToolkit.Mvvm.Input;
 using Microsoft.Extensions.DependencyInjection;
 using Scribble.Services;
 using Scribble.Services.DialogService;
@@ -88,10 +89,28 @@ public partial class MainView : UserControl
             _viewModel.UiStateViewModel.CenterZoomRequested += OnCenterZoomRequested;
             _viewModel.UiStateViewModel.ActiveToolChanged += OnActiveToolChanged;
 
-            LoadAllTools(viewModel);
-            // Ensure the canvas container gets focus so keybindings work immediately
-            Dispatcher.UIThread.Post(() => CanvasContainer.Focus());
+            OnAppStartUp(viewModel);
         }
+    }
+
+    private void OnAppStartUp(MainViewModel viewModel)
+    {
+        LoadAllTools(viewModel);
+        // Ensure the canvas container gets focus so keybindings work immediately
+        Dispatcher.UIThread.Post(() => CanvasContainer.Focus());
+
+        // Add keybindings for click event handlers
+        CanvasContainer.KeyBindings.Add(new KeyBinding
+        {
+            Gesture = new KeyGesture(Key.D1, KeyModifiers.Shift),
+            Command = new RelayCommand(() => ZoomToFitBtn_OnClick(null, null))
+        });
+
+        CanvasContainer.KeyBindings.Add(new KeyBinding
+        {
+            Gesture = new KeyGesture(Key.E, KeyModifiers.Control | KeyModifiers.Shift),
+            Command = new RelayCommand(() => ExportMenuOption_OnClick(null, null))
+        });
     }
 
     private void LoadAllTools(MainViewModel viewModel)

--- a/Scribble/Views/MainView.axaml.cs
+++ b/Scribble/Views/MainView.axaml.cs
@@ -89,6 +89,8 @@ public partial class MainView : UserControl
             _viewModel.UiStateViewModel.ActiveToolChanged += OnActiveToolChanged;
 
             LoadAllTools(viewModel);
+            // Ensure the canvas container gets focus so keybindings work immediately
+            Dispatcher.UIThread.Post(() => CanvasContainer.Focus());
         }
     }
 
@@ -406,12 +408,12 @@ public partial class MainView : UserControl
     }
 
     private void CloseExportImageWindow()
-        {
-            ExportImageWindow.IsVisible = false;
-            ExportImageWindowOverlay.IsVisible = false;
+    {
+        ExportImageWindow.IsVisible = false;
+        ExportImageWindowOverlay.IsVisible = false;
 
-            Dispatcher.UIThread.Post(() => CanvasContainer.Focus());
-        }
+        Dispatcher.UIThread.Post(() => CanvasContainer.Focus());
+    }
 
     private void CloseMenu()
     {

--- a/Scribble/Views/MainView.axaml.cs
+++ b/Scribble/Views/MainView.axaml.cs
@@ -93,6 +93,12 @@ public partial class MainView : UserControl
         }
     }
 
+    private bool CanExecuteKeyBinding()
+    {
+        var focusedElement = Utilities.GetTopLevel()?.FocusManager?.GetFocusedElement();
+        return focusedElement is not TextBox;
+    }
+
     private void OnAppStartUp(MainViewModel viewModel)
     {
         LoadAllTools(viewModel);
@@ -103,13 +109,13 @@ public partial class MainView : UserControl
         CanvasContainer.KeyBindings.Add(new KeyBinding
         {
             Gesture = new KeyGesture(Key.D1, KeyModifiers.Shift),
-            Command = new RelayCommand(() => ZoomToFitBtn_OnClick(null, null))
+            Command = new RelayCommand(() => ZoomToFitBtn_OnClick(null, null), CanExecuteKeyBinding)
         });
 
         CanvasContainer.KeyBindings.Add(new KeyBinding
         {
             Gesture = new KeyGesture(Key.E, KeyModifiers.Control | KeyModifiers.Shift),
-            Command = new RelayCommand(() => ExportMenuOption_OnClick(null, null))
+            Command = new RelayCommand(() => ExportMenuOption_OnClick(null, null), CanExecuteKeyBinding)
         });
     }
 
@@ -139,8 +145,8 @@ public partial class MainView : UserControl
                 KeyBindings.Add(new KeyBinding
                 {
                     Gesture = tool.HotKey,
-                    Command = viewModel.UiStateViewModel.SwitchToolCommand,
-                    CommandParameter = tool
+                    Command = new RelayCommand(() => viewModel.UiStateViewModel.SwitchToolCommand.Execute(tool),
+                        CanExecuteKeyBinding)
                 });
             }
         }

--- a/Scribble/Views/MainView.axaml.cs
+++ b/Scribble/Views/MainView.axaml.cs
@@ -88,39 +88,43 @@ public partial class MainView : UserControl
             _viewModel.UiStateViewModel.CenterZoomRequested += OnCenterZoomRequested;
             _viewModel.UiStateViewModel.ActiveToolChanged += OnActiveToolChanged;
 
-            // Load in all the pointer tools
-            viewModel.UiStateViewModel.AvailableTools.Clear();
-            var tools = new List<PointerTool>
-            {
-                new PencilTool("PencilTool", _canvasStateService),
-                new EraseTool("EraseTool", _canvasStateService),
-                new PanningTool("PanningTool", _canvasStateService, MainCanvas.InvalidateVisual),
-                new LineTool("LineTool", _canvasStateService),
-                new ArrowTool("ArrowTool", _canvasStateService),
-                new EllipseTool("EllipseTool", _canvasStateService),
-                new RectangleTool("RectangleTool", _canvasStateService),
-                new TextTool("TextTool", _canvasStateService, CanvasContainer),
-                new SelectTool("SelectTool", _canvasStateService, CanvasContainer),
-                new ImageTool("ImageTool", _canvasStateService, _fileService, _dialogService),
-            };
-            foreach (var tool in tools)
-            {
-                viewModel.UiStateViewModel.AvailableTools.Add(tool);
-
-                // Map the tool's HotKey to trigger the SelectToolCommand
-                if (tool.HotKey != null)
-                {
-                    KeyBindings.Add(new KeyBinding
-                    {
-                        Gesture = tool.HotKey,
-                        Command = viewModel.UiStateViewModel.SwitchToolCommand,
-                        CommandParameter = tool
-                    });
-                }
-            }
-
-            viewModel.UiStateViewModel.ActivePointerTool = tools.FirstOrDefault();
+            LoadAllTools(viewModel);
         }
+    }
+
+    private void LoadAllTools(MainViewModel viewModel)
+    {
+        viewModel.UiStateViewModel.AvailableTools.Clear();
+        var tools = new List<PointerTool>
+        {
+            new PencilTool("PencilTool", _canvasStateService),
+            new EraseTool("EraseTool", _canvasStateService),
+            new PanningTool("PanningTool", _canvasStateService, MainCanvas.InvalidateVisual),
+            new LineTool("LineTool", _canvasStateService),
+            new ArrowTool("ArrowTool", _canvasStateService),
+            new EllipseTool("EllipseTool", _canvasStateService),
+            new RectangleTool("RectangleTool", _canvasStateService),
+            new TextTool("TextTool", _canvasStateService, CanvasContainer),
+            new SelectTool("SelectTool", _canvasStateService, CanvasContainer),
+            new ImageTool("ImageTool", _canvasStateService, _fileService, _dialogService),
+        };
+        foreach (var tool in tools)
+        {
+            viewModel.UiStateViewModel.AvailableTools.Add(tool);
+
+            // Map the tool's HotKey to trigger the SwitchToolCommand
+            if (tool.HotKey != null)
+            {
+                KeyBindings.Add(new KeyBinding
+                {
+                    Gesture = tool.HotKey,
+                    Command = viewModel.UiStateViewModel.SwitchToolCommand,
+                    CommandParameter = tool
+                });
+            }
+        }
+
+        viewModel.UiStateViewModel.ActivePointerTool = tools.FirstOrDefault();
     }
 
     /// <summary>
@@ -401,6 +405,36 @@ public partial class MainView : UserControl
         return CameraState.ScreenToWorld(screenPos);
     }
 
+    private void CloseExportImageWindow()
+        {
+            ExportImageWindow.IsVisible = false;
+            ExportImageWindowOverlay.IsVisible = false;
+
+            Dispatcher.UIThread.Post(() => CanvasContainer.Focus());
+        }
+
+    private void CloseMenu()
+    {
+        MenuOptions.IsVisible = false;
+        MenuOverlay.IsVisible = false;
+
+        Dispatcher.UIThread.Post(() => CanvasContainer.Focus());
+    }
+
+    private void CloseLiveDrawingWindow()
+    {
+        LiveDrawingWindow.IsVisible = false;
+        LiveDrawingWindowOverlay.IsVisible = false;
+        Dispatcher.UIThread.Post(() => CanvasContainer.Focus());
+    }
+
+    private void CloseAboutScribbleWindow()
+    {
+        AboutScribbleWindow.IsVisible = false;
+        AboutScribbleWindowOverlay.IsVisible = false;
+        Dispatcher.UIThread.Post(() => CanvasContainer.Focus());
+    }
+
     private void MainCanvas_OnPointerMoved(object? sender, PointerEventArgs e)
     {
         var pointerCoordinates = GetPointerPosition(e);
@@ -672,28 +706,6 @@ public partial class MainView : UserControl
         CloseMenu();
     }
 
-    private void CloseMenu()
-    {
-        MenuOptions.IsVisible = false;
-        MenuOverlay.IsVisible = false;
-
-        Dispatcher.UIThread.Post(() => CanvasContainer.Focus());
-    }
-
-    private void CloseLiveDrawingWindow()
-    {
-        LiveDrawingWindow.IsVisible = false;
-        LiveDrawingWindowOverlay.IsVisible = false;
-        Dispatcher.UIThread.Post(() => CanvasContainer.Focus());
-    }
-
-    private void CloseAboutScribbleWindow()
-    {
-        AboutScribbleWindow.IsVisible = false;
-        AboutScribbleWindowOverlay.IsVisible = false;
-        Dispatcher.UIThread.Post(() => CanvasContainer.Focus());
-    }
-
     private void TransparentCanvasButton_OnClick(object? sender, RoutedEventArgs e)
     {
         CanvasBackgroundColorPicker.SelectedColor = Color.Parse("#a2000000");
@@ -711,18 +723,10 @@ public partial class MainView : UserControl
         LiveDrawingWindowOverlay.IsVisible = true;
     }
 
-    private async void RoomIdClipboardButton_OnClick(object? sender, RoutedEventArgs e)
+    private void RoomIdClipboardButton_OnClick(object? sender, RoutedEventArgs e)
     {
-        try
-        {
-            var clipboard = Utilities.GetTopLevel()?.Clipboard;
-            if (clipboard == null) return;
-            await clipboard.SetTextAsync(RoomIdTextBox.Text);
-        }
-        catch (Exception exception)
-        {
-            Console.WriteLine($"Failed to copy to clipboard - {exception.Message}");
-        }
+        var clipboard = Utilities.GetTopLevel()?.Clipboard;
+        clipboard?.SetTextAsync(RoomIdTextBox.Text);
     }
 
     private void RoomIdTextBox_OnKeyDown(object? sender, KeyEventArgs e)
@@ -760,14 +764,6 @@ public partial class MainView : UserControl
         CloseMenu();
         AboutScribbleWindow.IsVisible = true;
         AboutScribbleWindowOverlay.IsVisible = true;
-    }
-
-    private void CloseExportImageWindow()
-    {
-        ExportImageWindow.IsVisible = false;
-        ExportImageWindowOverlay.IsVisible = false;
-
-        Dispatcher.UIThread.Post(() => CanvasContainer.Focus());
     }
 
     private void ExportImageWindowOverlay_OnPointerPressed(object? sender, PointerPressedEventArgs e)


### PR DESCRIPTION
This pull request refactors keyboard shortcut handling and focus management in the `MainView` for improved reliability and maintainability. The main changes include moving keybinding definitions from the `UserControl` to the `Canvas` for better focus behavior, centralizing shortcut logic in code-behind, and ensuring that focus returns to the canvas after closing overlays. Additionally, it cleans up redundant or outdated properties and streamlines clipboard handling.

**Keybinding and Shortcut Management Improvements:**

- Moved all keybinding definitions from the `UserControl` level to the `Canvas` (`CanvasContainer`) in `MainView.axaml`, making the canvas focusable and ensuring keyboard shortcuts work reliably after interacting with overlays or dialogs. Also added new keybindings for menu actions and zoom.
- Removed `HotKey` attributes from button controls and handled all shortcut logic through centralized keybindings, reducing duplication and potential conflicts.

**Focus and Overlay Handling:**

- Refactored focus management so that after closing overlays or dialogs (such as export, menu, live drawing, or about windows), focus is returned to the canvas to re-enable keyboard shortcuts immediately. This logic is now centralized in dedicated methods.

**Keybinding Execution Logic:**

- Introduced a `CanExecuteKeyBinding` method to prevent keybindings from triggering when a `TextBox` is focused, avoiding accidental shortcut activation during text input.

**General Code and Usability Enhancements:**

- Simplified clipboard copy logic for the room ID, removing unnecessary async/try-catch code in favor of a direct call.
- Improved button formatting for clarity and consistency in the UI.

These changes collectively enhance the user experience by making keyboard shortcuts more reliable and intuitive, and by improving the maintainability of the shortcut system in the codebase.