### PR TITLE
Implement debounced autosave

### DIFF
--- a/Scribble.Shared/Lib/CanvasElements/CanvasElement.cs
+++ b/Scribble.Shared/Lib/CanvasElements/CanvasElement.cs
@@ -1,8 +1,11 @@
 using System.Text.Json.Serialization;
+using Scribble.Shared.Lib.CanvasElements.Strokes;
 
 namespace Scribble.Shared.Lib.CanvasElements;
 
 [JsonDerivedType(typeof(CanvasImage), typeDiscriminator: "CanvasImage")]
+[JsonDerivedType(typeof(DrawStroke), typeDiscriminator: "DrawStroke")]
+[JsonDerivedType(typeof(TextStroke), typeDiscriminator: "TextStroke")]
 public abstract class CanvasElement
 {
     public Guid Id { get; init; } = Guid.NewGuid();

--- a/Scribble/Extensions/ServiceCollectionExtensions.cs
+++ b/Scribble/Extensions/ServiceCollectionExtensions.cs
@@ -38,7 +38,7 @@ public static class ServiceCollectionExtensions
         collection.AddTransient<MainViewModel>();
 
         collection.AddSingleton<IFileService, AvaloniaFileService>();
-
         collection.AddSingleton<IDialogService, AvaloniaDialogService>();
+        collection.AddSingleton<AutoSaveService>();
     }
 }

--- a/Scribble/Services/AutoSaveService.cs
+++ b/Scribble/Services/AutoSaveService.cs
@@ -1,0 +1,184 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Scribble.Services.MultiUserDrawing;
+
+namespace Scribble.Services;
+
+/// <summary>
+/// Handles autosaving the canvas state and loading it on app startup
+/// </summary>
+public class AutoSaveService : IDisposable
+{
+    private readonly CanvasStateService _canvasStateService;
+    private readonly DocumentService _documentService;
+    private readonly MultiUserDrawingService _multiUserDrawingService;
+
+    private readonly string _appDataPath;
+    private readonly SemaphoreSlim _saveLock = new(1, 1);
+    private CancellationTokenSource? _cts;
+    private CancellationTokenSource? _maxDelayCts;
+    private bool _hasUnsavedChanges;
+
+    public AutoSaveService(CanvasStateService canvasStateService, DocumentService documentService,
+        MultiUserDrawingService multiUserDrawingService)
+    {
+        _canvasStateService = canvasStateService;
+        _documentService = documentService;
+        _multiUserDrawingService = multiUserDrawingService;
+
+        _canvasStateService.CanvasInvalidated += OnCanvasInvalidated;
+        _multiUserDrawingService.RoomChanged += room =>
+        {
+            if (room != null)
+            {
+                PauseAutoSave();
+            }
+        };
+
+        var baseDirectory = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        _appDataPath = Path.Combine(baseDirectory, "Scribble");
+        // Create the app data folder if it doesn't exist
+        Directory.CreateDirectory(_appDataPath);
+
+        LoadAutoSavedState();
+    }
+
+    private async void OnCanvasInvalidated()
+    {
+        try
+        {
+            if (_multiUserDrawingService.Room != null) return;
+            if (!_hasUnsavedChanges)
+            {
+                _hasUnsavedChanges = true;
+                _ = StartMaxDelayTimer();
+            }
+
+            await AutoSaveAsync();
+        }
+        catch (TaskCanceledException)
+        {
+            // Expected behaviour
+        }
+    }
+
+    /// <summary>
+    /// Starts a timer that will wait a max of 10 seconds before saving the canvas state
+    /// </summary>
+    private async Task StartMaxDelayTimer()
+    {
+        try
+        {
+            _maxDelayCts?.Cancel();
+            _maxDelayCts?.Dispose();
+            _maxDelayCts = new CancellationTokenSource();
+            var token = _maxDelayCts.Token;
+            await Task.Delay(TimeSpan.FromSeconds(10), token);
+            await WriteToDiskAsync();
+        }
+        catch (TaskCanceledException)
+        {
+            // Expected behaviour
+        }
+    }
+
+    /// <summary>
+    /// Loads the autosaved state from the autosaved state file
+    /// </summary>
+    private void LoadAutoSavedState()
+    {
+        var autosavedStateFilePath = Path.Combine(_appDataPath, "autosave.scribble");
+        if (File.Exists(autosavedStateFilePath))
+        {
+            _ = _documentService.LoadAsync(File.OpenRead(autosavedStateFilePath));
+        }
+    }
+
+    /// <summary>
+    /// Saves the canvas state to the autosaved state file
+    /// </summary>
+    private async Task AutoSaveAsync()
+    {
+        _cts?.Cancel();
+        _cts?.Dispose();
+
+        _cts = new CancellationTokenSource();
+        var token = _cts.Token;
+        try
+        {
+            // wait for the debounce period
+            await Task.Delay(TimeSpan.FromSeconds(2), token);
+
+            await WriteToDiskAsync();
+            _maxDelayCts?.Cancel();
+            _maxDelayCts?.Dispose();
+            _maxDelayCts = null;
+        }
+        catch (TaskCanceledException)
+        {
+            // Ignore, this is expected behaviour
+        }
+    }
+
+    /// <summary>
+    /// Writes the canvas state to the autosaved state file
+    /// </summary>
+    private async Task WriteToDiskAsync()
+    {
+        // ensures only one write operation runs at a time
+        await _saveLock.WaitAsync();
+        try
+        {
+            // Write the data to a temporary file and move it to the autosaved state file
+            if (_hasUnsavedChanges)
+            {
+                var autosavedStateFilePath = Path.Combine(_appDataPath, "autosave.scribble");
+                var tempPath = Path.Combine(_appDataPath, "autosave.scribble.tmp");
+                await using var fileStream = File.OpenWrite(tempPath);
+                await _documentService.SaveAsync(fileStream);
+                File.Move(tempPath, autosavedStateFilePath, overwrite: true);
+                _hasUnsavedChanges = false;
+            }
+        }
+        finally
+        {
+            _saveLock.Release();
+        }
+    }
+
+    private void PauseAutoSave()
+    {
+        _cts?.Cancel();
+        _cts?.Dispose();
+        _cts = null;
+        _maxDelayCts?.Cancel();
+        _maxDelayCts?.Dispose();
+        _maxDelayCts = null;
+        _hasUnsavedChanges = false;
+    }
+
+    /// <summary>
+    /// Deletes the autosaved state file
+    /// </summary>
+    public void DeleteAutoSavedState()
+    {
+        var autosavedStateFilePath = Path.Combine(_appDataPath, "autosave.scribble");
+        if (File.Exists(autosavedStateFilePath))
+        {
+            File.Delete(autosavedStateFilePath);
+        }
+    }
+
+    public void Dispose()
+    {
+        _cts?.Cancel();
+        _cts?.Dispose();
+        _cts = null;
+        _maxDelayCts?.Cancel();
+        _maxDelayCts?.Dispose();
+        _maxDelayCts = null;
+        _saveLock.Dispose();
+    }
+}

--- a/Scribble/Services/DocumentService.cs
+++ b/Scribble/Services/DocumentService.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
+using Avalonia.Threading;
 using Scribble.Dtos;
 using Scribble.Shared.Lib.CanvasElements;
 using Scribble.Shared.Lib.CanvasElements.Strokes;
@@ -23,69 +25,77 @@ public class DocumentService
 
     public async Task SaveAsync(Stream stream)
     {
-        var canvasElements = _canvasStateService.CanvasElements;
-        var backgroundColor = _canvasStateService.BackgroundColor;
-
-        await using var streamWriter = new StreamWriter(stream);
-
-        var serializerOptions = new JsonSerializerOptions
+        List<CanvasElement> canvasElements = [];
+        SKColor backgroundColor = default;
+        Dispatcher.UIThread.Invoke(() =>
         {
-            WriteIndented = true,
-            Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
-        };
-        var jsonCanvasStrokes = new JsonArray();
-        var jsonCanvasImages = new JsonArray();
-        Dictionary<string, Guid> imageBase64EncodedStrings = [];
-        foreach (var element in canvasElements)
+            canvasElements = _canvasStateService.CanvasElements.ToList();
+            backgroundColor = _canvasStateService.BackgroundColor;
+        });
+
+        await Task.Run(async () =>
         {
-            if (element is Stroke stroke)
+            await using var streamWriter = new StreamWriter(stream);
+
+            var serializerOptions = new JsonSerializerOptions
             {
-                jsonCanvasStrokes.Add(JsonSerializer.SerializeToNode(stroke, serializerOptions));
-            }
-            else if (element is CanvasImage canvasImage)
+                WriteIndented = true,
+                Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
+            };
+            var jsonCanvasStrokes = new JsonArray();
+            var jsonCanvasImages = new JsonArray();
+            Dictionary<string, Guid> imageBase64EncodedStrings = [];
+            foreach (var element in canvasElements)
             {
-                Guid fileId;
-                if (imageBase64EncodedStrings.ContainsKey(canvasImage.ImageBase64String))
+                if (element is Stroke stroke)
                 {
-                    fileId = imageBase64EncodedStrings[canvasImage.ImageBase64String];
+                    jsonCanvasStrokes.Add(JsonSerializer.SerializeToNode(stroke, serializerOptions));
                 }
-                else
+                else if (element is CanvasImage canvasImage)
                 {
-                    fileId = Guid.NewGuid();
-                    imageBase64EncodedStrings[canvasImage.ImageBase64String] = fileId;
+                    Guid fileId;
+                    if (imageBase64EncodedStrings.ContainsKey(canvasImage.ImageBase64String))
+                    {
+                        fileId = imageBase64EncodedStrings[canvasImage.ImageBase64String];
+                    }
+                    else
+                    {
+                        fileId = Guid.NewGuid();
+                        imageBase64EncodedStrings[canvasImage.ImageBase64String] = fileId;
+                    }
+
+                    var canvasImageDto = new CanvasImageDto
+                    {
+                        Id = canvasImage.Id,
+                        Width = canvasImage.Bounds.Width,
+                        Height = canvasImage.Bounds.Height,
+                        X = canvasImage.Bounds.Left,
+                        Y = canvasImage.Bounds.Top,
+                        LayerIndex = canvasImage.LayerIndex,
+                        FileId = fileId
+                    };
+                    jsonCanvasImages.Add(JsonSerializer.SerializeToNode(canvasImageDto, serializerOptions));
                 }
-
-                var canvasImageDto = new CanvasImageDto
-                {
-                    Id = canvasImage.Id,
-                    Width = canvasImage.Bounds.Width,
-                    Height = canvasImage.Bounds.Height,
-                    X = canvasImage.Bounds.Left,
-                    Y = canvasImage.Bounds.Top,
-                    LayerIndex = canvasImage.LayerIndex,
-                    FileId = fileId
-                };
-                jsonCanvasImages.Add(JsonSerializer.SerializeToNode(canvasImageDto, serializerOptions));
             }
-        }
 
-        var files = new JsonObject();
-        foreach (var (base64String, fileId) in imageBase64EncodedStrings)
-        {
-            files.Add(fileId.ToString(), base64String);
-        }
-
-        var canvasState = new JsonObject
-        {
-            ["elements"] = new JsonObject
+            var files = new JsonObject();
+            foreach (var (base64String, fileId) in imageBase64EncodedStrings)
             {
-                ["strokes"] = jsonCanvasStrokes,
-                ["images"] = jsonCanvasImages
-            },
-            ["files"] = files,
-            ["backgroundColor"] = backgroundColor.ToString()
-        };
-        await streamWriter.WriteAsync(canvasState.ToJsonString(serializerOptions));
+                files.Add(fileId.ToString(), base64String);
+            }
+
+            var canvasState = new JsonObject
+            {
+                ["elements"] = new JsonObject
+                {
+                    ["strokes"] = jsonCanvasStrokes,
+                    ["images"] = jsonCanvasImages
+                },
+                ["files"] = files,
+                ["backgroundColor"] = backgroundColor.ToString()
+            };
+            await streamWriter.WriteAsync(canvasState.ToJsonString(serializerOptions));
+        });
     }
 
     public async Task LoadAsync(Stream stream)

--- a/Scribble/ViewModels/DocumentViewModel.cs
+++ b/Scribble/ViewModels/DocumentViewModel.cs
@@ -19,16 +19,18 @@ public partial class DocumentViewModel : ViewModelBase
     private readonly CanvasStateService _canvasStateService;
     private readonly DocumentService _documentService;
     private readonly MultiUserDrawingService _multiUserDrawingService;
+    private readonly AutoSaveService _autoSaveService;
 
     public DocumentViewModel(IFileService fileService, IDialogService dialogService,
         CanvasStateService canvasStateService, DocumentService documentService,
-        MultiUserDrawingService multiUserDrawingService)
+        MultiUserDrawingService multiUserDrawingService, AutoSaveService autoSaveService)
     {
         _fileService = fileService;
         _dialogService = dialogService;
         _canvasStateService = canvasStateService;
         _documentService = documentService;
         _multiUserDrawingService = multiUserDrawingService;
+        _autoSaveService = autoSaveService;
     }
 
     [RelayCommand]
@@ -45,6 +47,7 @@ public partial class DocumentViewModel : ViewModelBase
         {
             await using var stream = await file.OpenWriteAsync();
             await _documentService.SaveAsync(stream);
+            _autoSaveService.DeleteAutoSavedState();
         }
     }
 

--- a/Scribble/ViewModels/MultiUserDrawingViewModel.cs
+++ b/Scribble/ViewModels/MultiUserDrawingViewModel.cs
@@ -39,7 +39,7 @@ public partial class MultiUserDrawingViewModel : ViewModelBase
     private string _roomId = string.Empty;
 
     [ObservableProperty] [NotifyCanExecuteChangedFor(nameof(ToggleRoomConnectionCommand))]
-    private string _clientDisplayName = "Bootlicker";
+    private string _clientDisplayName = "Archer";
 
     [ObservableProperty] [NotifyCanExecuteChangedFor(nameof(SendMessageCommand))]
     private string _message = string.Empty;
@@ -129,7 +129,7 @@ public partial class MultiUserDrawingViewModel : ViewModelBase
 
         if (string.IsNullOrWhiteSpace(ClientDisplayName))
         {
-            ClientDisplayName = "Bootlicker";
+            ClientDisplayName = "Archer";
         }
 
         var cleanedMessage = Message.Trim();

--- a/Scribble/Views/MainView.axaml
+++ b/Scribble/Views/MainView.axaml
@@ -798,7 +798,7 @@
                         <TextBlock FontSize="12" TextWrapping="Wrap" Foreground="WhiteSmoke">
                             If the room id doesn't belong to any active room, the room is automatically created
                         </TextBlock>
-                        <TextBlock FontSize="12" TextWrapping="Wrap" Foreground="WhiteSmoke">
+                        <TextBlock FontSize="12" TextWrapping="Wrap" Foreground="WhiteSmoke" FontStyle="Italic">
                             Note: It might take a minute for the initial connection to be established
                         </TextBlock>
                     </StackPanel>


### PR DESCRIPTION
This pull request introduces an autosave feature for the canvas, ensuring user work is automatically saved and restored if the app closes unexpectedly. The main changes include adding the new `AutoSaveService`, integrating it into the application lifecycle, and updating save logic to be thread-safe and UI-thread aware.

**Autosave functionality:**

* Added a new `AutoSaveService` class that manages automatic saving and loading of the canvas state, including debounce logic, file handling, and integration with multi-user drawing mode. (`Scribble/Services/AutoSaveService.cs`)
* Registered `AutoSaveService` as a singleton in the service collection, making it available throughout the app. (`Scribble/Extensions/ServiceCollectionExtensions.cs`)

**Integration with existing services and view models:**

* Injected `AutoSaveService` into `DocumentViewModel` and ensured that autosave state is deleted after a successful manual save. (`Scribble/ViewModels/DocumentViewModel.cs`)

**Thread-safety and UI-thread handling:**

* Updated `DocumentService.SaveAsync` to fetch canvas elements and background color on the UI thread, then serialize and save on a background thread, preventing UI freezes and ensuring thread safety. (`Scribble/Services/DocumentService.cs`)