### PR TITLE
Create autosave service and write unit tests

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,11 +17,17 @@
     <PackageVersion Include="Avalonia.Browser" Version="11.3.6" />
     <PackageVersion Include="Avalonia.Android" Version="11.3.6" />
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+    <PackageVersion Include="FluentAssertions" Version="8.10.0" />
     <PackageVersion Include="MessageBox.Avalonia" Version="3.3.1.1" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.2" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
+    <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="SkiaSharp" Version="2.88.9" />
     <PackageVersion Include="Xamarin.AndroidX.Core.SplashScreen" Version="1.0.1.15" />
+    <PackageVersion Include="xunit.v3" Version="3.2.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,6 +23,7 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.2" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
+    <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
     <PackageVersion Include="SkiaSharp" Version="2.88.9" />
     <PackageVersion Include="Xamarin.AndroidX.Core.SplashScreen" Version="1.0.1.15" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,6 +8,7 @@
     <!-- Important: keep version in sync! -->
     <PackageVersion Include="Avalonia" Version="11.3.6" />
     <PackageVersion Include="Avalonia.Controls.ColorPicker" Version="11.3.6" />
+    <PackageVersion Include="Avalonia.Headless.XUnit" Version="12.0.5" />
     <PackageVersion Include="Avalonia.Skia" Version="11.3.6" />
     <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.3.6" />
     <PackageVersion Include="Avalonia.Fonts.Inter" Version="11.3.6" />

--- a/Scribble.Server/Scribble.Server.csproj
+++ b/Scribble.Server/Scribble.Server.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net10.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>

--- a/Scribble.Shared/Lib/CanvasElements/CanvasElement.cs
+++ b/Scribble.Shared/Lib/CanvasElements/CanvasElement.cs
@@ -1,8 +1,11 @@
 using System.Text.Json.Serialization;
+using Scribble.Shared.Lib.CanvasElements.Strokes;
 
 namespace Scribble.Shared.Lib.CanvasElements;
 
 [JsonDerivedType(typeof(CanvasImage), typeDiscriminator: "CanvasImage")]
+[JsonDerivedType(typeof(DrawStroke), typeDiscriminator: "DrawStroke")]
+[JsonDerivedType(typeof(TextStroke), typeDiscriminator: "TextStroke")]
 public abstract class CanvasElement
 {
     public Guid Id { get; init; } = Guid.NewGuid();

--- a/Scribble.Shared/Lib/CanvasElements/Strokes/DrawStroke.cs
+++ b/Scribble.Shared/Lib/CanvasElements/Strokes/DrawStroke.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace Scribble.Shared.Lib.CanvasElements.Strokes;
 
 /// <summary>
@@ -13,6 +15,6 @@ public class DrawStroke : PaintableStroke
     /// <summary>
     /// The raw input points that build up the stroke
     /// </summary>
-    [System.Text.Json.Serialization.JsonIgnore]
+    [JsonIgnore]
     public List<StrokePoint> RawPoints { get; init; } = [];
 }

--- a/Scribble.Shared/Lib/StrokePaint.cs
+++ b/Scribble.Shared/Lib/StrokePaint.cs
@@ -38,7 +38,9 @@ public class StrokePaint
 
     public StrokePaint Clone()
     {
-        return (StrokePaint)MemberwiseClone();
+        var clone = (StrokePaint)MemberwiseClone();
+        clone.DashIntervals = DashIntervals?.ToArray();
+        return clone;
     }
 
     public SKPaint GetCachedSkPaint()

--- a/Scribble.Tests/ConverterTests/BoolToBrushConverterTests.cs
+++ b/Scribble.Tests/ConverterTests/BoolToBrushConverterTests.cs
@@ -1,0 +1,65 @@
+using System.Globalization;
+using Avalonia.Data;
+using Avalonia.Headless.XUnit;
+using Avalonia.Media;
+using FluentAssertions;
+using Scribble.Converters;
+
+namespace Scribble.Tests.ConverterTests;
+
+public class BoolToBrushConverterTests
+{
+    private readonly BoolToBrushConverter _sut = new();
+    private readonly Type _targetType = typeof(object);
+    private const string OwnershipStatus = "ownershipstatus";
+    private const string SentStatus = "sentstatus";
+
+    [AvaloniaFact]
+    public void Convert_OwnershipStatusTrue_ReturnsOwnMessageBrush()
+    {
+        var result = (SolidColorBrush)_sut.Convert(true, _targetType, OwnershipStatus, CultureInfo.InvariantCulture);
+
+        result.Should().BeEquivalentTo(BoolToBrushConverter.OwnMessageBrush);
+    }
+
+    [AvaloniaFact]
+    public void Convert_OwnershipStatusFalse_ReturnsOtherMessageBrush()
+    {
+        var result = (SolidColorBrush)_sut.Convert(false, _targetType, OwnershipStatus, CultureInfo.InvariantCulture);
+
+        result.Should().BeEquivalentTo(BoolToBrushConverter.OtherMessageBrush);
+    }
+
+    [AvaloniaFact]
+    public void Convert_SentStatusTrue_ReturnsSentMessageBrush()
+    {
+        var result = (SolidColorBrush)_sut.Convert(true, _targetType, SentStatus, CultureInfo.InvariantCulture);
+
+        result.Should().BeEquivalentTo(BoolToBrushConverter.SentMessageBrush);
+    }
+
+    [AvaloniaFact]
+    public void Convert_SentStatusFalse_ReturnsPendingMessageBrush()
+    {
+        var result = (SolidColorBrush)_sut.Convert(false, _targetType, SentStatus, CultureInfo.InvariantCulture);
+
+        result.Should().BeEquivalentTo(BoolToBrushConverter.PendingMessageBrush);
+    }
+
+    [AvaloniaFact]
+    public void Convert_InvalidParameter_ReturnsBindingNotificationWithError()
+    {
+        var result = _sut.Convert(true, _targetType, "invalid", CultureInfo.InvariantCulture);
+
+        result.Should().BeOfType<BindingNotification>()
+            .Which.ErrorType.Should().Be(BindingErrorType.Error);
+    }
+
+    [AvaloniaFact]
+    public void ConvertBack_ThrowsNotSupportedException()
+    {
+        Action act = () => _sut.ConvertBack(null, _targetType, null, CultureInfo.InvariantCulture);
+
+        act.Should().Throw<NotSupportedException>();
+    }
+}

--- a/Scribble.Tests/ConverterTests/EnumToBoolConverterTests.cs
+++ b/Scribble.Tests/ConverterTests/EnumToBoolConverterTests.cs
@@ -1,0 +1,74 @@
+using Avalonia.Data;
+using FluentAssertions;
+using Scribble.Converters;
+using Scribble.Shared.Lib;
+using System.Globalization;
+
+namespace Scribble.Tests.ConverterTests;
+
+public class EnumToBoolConverterTests
+{
+    private readonly EnumToBoolConverter _sut = new();
+    private readonly CultureInfo _culture = CultureInfo.InvariantCulture;
+    private readonly Type _targetType = typeof(bool);
+
+    // Convert
+
+    [Fact]
+    public void Convert_ValueMatchesParameter_ReturnsTrue()
+    {
+        var result = _sut.Convert(ToolType.Pencil, _targetType, ToolType.Pencil, _culture);
+
+        result.Should().Be(true);
+    }
+
+    [Fact]
+    public void Convert_ValueDoesNotMatchParameter_ReturnsFalse()
+    {
+        var result = _sut.Convert(ToolType.Pencil, _targetType, ToolType.Line, _culture);
+
+        result.Should().Be(false);
+    }
+
+    [Fact]
+    public void Convert_NullValue_ReturnsFalse()
+    {
+        var result = _sut.Convert(null, _targetType, ToolType.Pencil, _culture);
+
+        result.Should().Be(false);
+    }
+
+    // ConvertBack
+
+    [Fact]
+    public void ConvertBack_TrueWithNonNullParameter_ReturnsParameter()
+    {
+        var result = _sut.ConvertBack(true, typeof(ToolType), ToolType.Line, _culture);
+
+        result.Should().Be(ToolType.Line);
+    }
+
+    [Fact]
+    public void ConvertBack_FalseWithNonNullParameter_ReturnsDoNothing()
+    {
+        var result = _sut.ConvertBack(false, typeof(ToolType), ToolType.Line, _culture);
+
+        result.Should().Be(BindingOperations.DoNothing);
+    }
+
+    [Fact]
+    public void ConvertBack_TrueWithNullParameter_ReturnsDoNothing()
+    {
+        var result = _sut.ConvertBack(true, typeof(ToolType), null, _culture);
+
+        result.Should().Be(BindingOperations.DoNothing);
+    }
+
+    [Fact]
+    public void ConvertBack_NullValue_ReturnsDoNothing()
+    {
+        var result = _sut.ConvertBack(null, typeof(ToolType), ToolType.Pencil, _culture);
+
+        result.Should().Be(BindingOperations.DoNothing);
+    }
+}

--- a/Scribble.Tests/ConverterTests/SKColorJsonConverterTests.cs
+++ b/Scribble.Tests/ConverterTests/SKColorJsonConverterTests.cs
@@ -158,8 +158,7 @@ public class SKColorJsonConverterTests
         result.Should().Be(expected);
     }
 
-    // ── Round-trip ─────────────────────────────────────────────────────────────
-
+    // Round-trip
     [Theory]
     [InlineData(255, 0, 0, 255)]
     [InlineData(0, 255, 0, 255)]

--- a/Scribble.Tests/ConverterTests/SKColorJsonConverterTests.cs
+++ b/Scribble.Tests/ConverterTests/SKColorJsonConverterTests.cs
@@ -1,0 +1,209 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using FluentAssertions;
+using Scribble.Shared.Converters;
+using SkiaSharp;
+
+namespace Scribble.Tests.ConverterTests;
+
+public class SKColorJsonConverterTests
+{
+    private static readonly JsonSerializerOptions Options = new()
+    {
+        Converters = { new SKColorJsonConverter() }
+    };
+
+    private class ColorPayload
+    {
+        [JsonConverter(typeof(SKColorJsonConverter))]
+        public SKColor Color { get; init; }
+    }
+
+    // Write
+    [Fact]
+    public void Write_OpaqueRed_WritesHexString()
+    {
+        var color = new SKColor(255, 0, 0, 255);
+
+        var json = JsonSerializer.Serialize(color, Options);
+
+        Console.WriteLine(color);
+        json.Should().Be($"\"{color}\"");
+    }
+
+    [Fact]
+    public void Write_TransparentColor_IncludesAlphaInHexString()
+    {
+        var color = new SKColor(128, 255, 64, 0);
+
+        var json = JsonSerializer.Serialize(color, Options);
+
+        json.Should().Be($"\"{color}\"");
+    }
+
+    [Fact]
+    public void Write_Black_WritesHexString()
+    {
+        var color = SKColors.Black;
+
+        var json = JsonSerializer.Serialize(color, Options);
+
+        json.Should().Be($"\"{color}\"");
+    }
+
+    [Fact]
+    public void Write_White_WritesHexString()
+    {
+        var color = SKColors.White;
+
+        var json = JsonSerializer.Serialize(color, Options);
+
+        json.Should().Be($"\"{color}\"");
+    }
+
+    [Fact]
+    public void Write_FullyTransparent_WritesHexString()
+    {
+        var color = SKColors.Transparent;
+
+        var json = JsonSerializer.Serialize(color, Options);
+
+        json.Should().Be($"\"{color}\"");
+    }
+
+    // Read
+    [Fact]
+    public void Read_EightDigitHex_ParsesCorrectly()
+    {
+        var color = new SKColor(255, 0, 0, 255);
+        var json = $"\"{color}\"";
+
+        var result = JsonSerializer.Deserialize<SKColor>(json, Options);
+
+        result.Should().Be(color);
+    }
+
+    [Fact]
+    public void Read_ColorWithAlpha_ParsesCorrectly()
+    {
+        var color = new SKColor(0, 128, 255, 64);
+        var json = $"\"{color}\"";
+
+        var result = JsonSerializer.Deserialize<SKColor>(json, Options);
+
+        result.Should().Be(color);
+    }
+
+    [Fact]
+    public void Read_BlackHex_ParsesCorrectly()
+    {
+        var json = $"\"{SKColors.Black}\"";
+
+        var result = JsonSerializer.Deserialize<SKColor>(json, Options);
+
+        result.Should().Be(SKColors.Black);
+    }
+
+    [Fact]
+    public void Read_WhiteHex_ParsesCorrectly()
+    {
+        var json = $"\"{SKColors.White}\"";
+
+        var result = JsonSerializer.Deserialize<SKColor>(json, Options);
+
+        result.Should().Be(SKColors.White);
+    }
+
+    [Fact]
+    public void Read_FullyTransparentHex_ParsesCorrectly()
+    {
+        var json = $"\"{SKColors.Transparent}\"";
+
+        var result = JsonSerializer.Deserialize<SKColor>(json, Options);
+
+        result.Should().Be(SKColors.Transparent);
+    }
+
+    [Fact]
+    public void Read_ShortSixDigitHex_ParsesAsOpaqueColor()
+    {
+        // SKColor.Parse accepts "#RRGGBB" and treats alpha as 0xFF
+        var result = JsonSerializer.Deserialize<SKColor>("\"#FF0000\"", Options);
+
+        result.Red.Should().Be(255);
+        result.Green.Should().Be(0);
+        result.Blue.Should().Be(0);
+        result.Alpha.Should().Be(255);
+    }
+
+    [Fact]
+    public void Read_HexWithoutHash_ParsesCorrectly()
+    {
+        // SKColor.Parse accepts input without the leading '#'
+        var expected = new SKColor(255, 0, 0, 255);
+
+        var result = JsonSerializer.Deserialize<SKColor>("\"FFFF0000\"", Options);
+
+        result.Should().Be(expected);
+    }
+
+    [Fact]
+    public void Read_LowercaseHex_ParsesCorrectly()
+    {
+        var expected = new SKColor(0, 255, 0, 255);
+        var json = $"\"{expected.ToString().ToLowerInvariant()}\"";
+
+        var result = JsonSerializer.Deserialize<SKColor>(json, Options);
+
+        result.Should().Be(expected);
+    }
+
+    // ── Round-trip ─────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(255, 0, 0, 255)]
+    [InlineData(0, 255, 0, 255)]
+    [InlineData(0, 0, 255, 255)]
+    [InlineData(128, 64, 32, 200)]
+    [InlineData(0, 0, 0, 0)]
+    [InlineData(255, 255, 255, 255)]
+    public void RoundTrip_SerializeDeserialize_ReturnsOriginalColor(
+        byte r, byte g, byte b, byte a)
+    {
+        var original = new SKColor(r, g, b, a);
+
+        var json = JsonSerializer.Serialize(original, Options);
+        var result = JsonSerializer.Deserialize<SKColor>(json, Options);
+
+        result.Should().Be(original);
+    }
+
+    [Fact]
+    public void RoundTrip_ColorInObject_PreservesValue()
+    {
+        var payload = new ColorPayload { Color = new SKColor(100, 150, 200, 220) };
+
+        var json = JsonSerializer.Serialize(payload, Options);
+        var result = JsonSerializer.Deserialize<ColorPayload>(json, Options);
+
+        result.Should().NotBeNull();
+        result.Color.Should().Be(payload.Color);
+    }
+
+    // Error Handling
+    [Fact]
+    public void Read_InvalidHexString_ThrowsException()
+    {
+        var act = () => JsonSerializer.Deserialize<SKColor>("\"not-a-color\"", Options);
+
+        act.Should().Throw<Exception>();
+    }
+
+    [Fact]
+    public void Read_EmptyString_ThrowsException()
+    {
+        var act = () => JsonSerializer.Deserialize<SKColor>("\"\"", Options);
+
+        act.Should().Throw<Exception>();
+    }
+}

--- a/Scribble.Tests/ConverterTests/SKMatrixJsonConverterTests.cs
+++ b/Scribble.Tests/ConverterTests/SKMatrixJsonConverterTests.cs
@@ -1,0 +1,150 @@
+using System.Text.Json;
+using FluentAssertions;
+using Scribble.Shared.Converters;
+using SkiaSharp;
+
+namespace Scribble.Tests.ConverterTests;
+
+public class SKMatrixJsonConverterTests
+{
+    private static readonly JsonSerializerOptions Options = new()
+    {
+        Converters = { new SKMatrixJsonConverter() }
+    };
+
+    // Write
+    [Fact]
+    public void Write_IdentityMatrix_ProducesArrayOfNineElements()
+    {
+        var matrix = SKMatrix.Identity;
+
+        var json = JsonSerializer.Serialize(matrix, Options);
+
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetArrayLength().Should().Be(9);
+    }
+
+    [Fact]
+    public void Write_IdentityMatrix_ValuesMatchMatrixValues()
+    {
+        var matrix = SKMatrix.Identity;
+
+        var json = JsonSerializer.Serialize(matrix, Options);
+
+        using var doc = JsonDocument.Parse(json);
+        var elements = doc.RootElement.EnumerateArray().Select(e => e.GetSingle()).ToArray();
+        elements.Should().Equal(matrix.Values);
+    }
+
+    [Fact]
+    public void Write_ScaleMatrix_ProducesCorrectScaleValues()
+    {
+        var matrix = SKMatrix.CreateScale(2f, 3f);
+
+        var json = JsonSerializer.Serialize(matrix, Options);
+
+        using var doc = JsonDocument.Parse(json);
+        var elements = doc.RootElement.EnumerateArray().Select(e => e.GetSingle()).ToArray();
+        elements.Should().Equal(matrix.Values);
+    }
+
+    [Fact]
+    public void Write_TranslationMatrix_ProducesCorrectTranslationValues()
+    {
+        var matrix = SKMatrix.CreateTranslation(100f, 200f);
+
+        var json = JsonSerializer.Serialize(matrix, Options);
+
+        using var doc = JsonDocument.Parse(json);
+        var elements = doc.RootElement.EnumerateArray().Select(e => e.GetSingle()).ToArray();
+        elements.Should().Equal(matrix.Values);
+    }
+
+    // Read
+    [Fact]
+    public void Read_IdentityMatrixJson_ReturnsIdentityMatrix()
+    {
+        var json = JsonSerializer.Serialize(SKMatrix.Identity, Options);
+
+        var result = JsonSerializer.Deserialize<SKMatrix>(json, Options);
+
+        result.Values.Should().Equal(SKMatrix.Identity.Values);
+    }
+
+    [Fact]
+    public void Read_ScaleMatrixJson_ReturnsCorrectMatrix()
+    {
+        var original = SKMatrix.CreateScale(4f, 5f);
+        var json = JsonSerializer.Serialize(original, Options);
+
+        var result = JsonSerializer.Deserialize<SKMatrix>(json, Options);
+
+        result.Values.Should().Equal(original.Values);
+    }
+
+    [Fact]
+    public void Read_NonArrayToken_ThrowsJsonException()
+    {
+        var act = () => JsonSerializer.Deserialize<SKMatrix>("\"not an array\"", Options);
+
+        act.Should().Throw<JsonException>();
+    }
+
+    [Fact]
+    public void Read_ArrayWithTooFewElements_ThrowsJsonException()
+    {
+        // Only 3 elements instead of 9
+        var act = () => JsonSerializer.Deserialize<SKMatrix>("[1,0,0]", Options);
+
+        act.Should().Throw<JsonException>();
+    }
+
+    [Fact]
+    public void Read_ArrayWithTooManyElements_ThrowsJsonException()
+    {
+        // 10 elements, one too many
+        var act = () => JsonSerializer.Deserialize<SKMatrix>("[1,0,0,0,1,0,0,0,1,99]", Options);
+
+        act.Should().Throw<JsonException>();
+    }
+
+    // Round-trip
+
+    [Fact]
+    public void RoundTrip_IdentityMatrix_PreservesAllValues()
+    {
+        var original = SKMatrix.Identity;
+
+        var json = JsonSerializer.Serialize(original, Options);
+        var result = JsonSerializer.Deserialize<SKMatrix>(json, Options);
+
+        result.Values.Should().Equal(original.Values);
+    }
+
+    [Fact]
+    public void RoundTrip_ScaleAndTranslateMatrix_PreservesAllValues()
+    {
+        var original = SKMatrix.CreateScale(2f, 3f)
+            .PostConcat(SKMatrix.CreateTranslation(50f, 75f));
+
+        var json = JsonSerializer.Serialize(original, Options);
+        var result = JsonSerializer.Deserialize<SKMatrix>(json, Options);
+
+        result.Values.Should().Equal(original.Values);
+    }
+
+    [Fact]
+    public void RoundTrip_RotationMatrix_PreservesAllValues()
+    {
+        var original = SKMatrix.CreateRotationDegrees(45f);
+
+        var json = JsonSerializer.Serialize(original, Options);
+        var result = JsonSerializer.Deserialize<SKMatrix>(json, Options);
+
+        // Float serialization may introduce tiny rounding; allow a small tolerance
+        for (int i = 0; i < 9; i++)
+        {
+            result.Values[i].Should().BeApproximately(original.Values[i], 1e-5f);
+        }
+    }
+}

--- a/Scribble.Tests/ConverterTests/SKPathJsonConverterTests.cs
+++ b/Scribble.Tests/ConverterTests/SKPathJsonConverterTests.cs
@@ -1,0 +1,138 @@
+using System.Text.Json;
+using FluentAssertions;
+using Scribble.Shared.Converters;
+using SkiaSharp;
+
+namespace Scribble.Tests.ConverterTests;
+
+public class SKPathJsonConverterTests
+{
+    private static readonly JsonSerializerOptions Options = new()
+    {
+        Converters = { new SKPathJsonConverter() }
+    };
+
+    // Write
+    [Fact]
+    public void Write_EmptyPath_ProducesEmptyString()
+    {
+        var path = new SKPath();
+
+        var json = JsonSerializer.Serialize(path, Options);
+
+        json.Should().Be("\"\"");
+    }
+
+    [Fact]
+    public void Write_PathWithLine_ProducesSvgMoveAndLineCommands()
+    {
+        // A MoveTo alone produces no SVG output in Skia; a drawing operation is required
+        var path = new SKPath();
+        path.MoveTo(0f, 0f);
+        path.LineTo(10f, 20f);
+
+        var json = JsonSerializer.Serialize(path, Options);
+
+        json.Should().Contain("M").And.Contain("L");
+    }
+
+    [Fact]
+    public void Write_PathWithLine_ProducesSvgLineCommand()
+    {
+        var path = new SKPath();
+        path.MoveTo(0f, 0f);
+        path.LineTo(10f, 10f);
+
+        var json = JsonSerializer.Serialize(path, Options);
+
+        json.Should().Contain("L");
+    }
+
+    [Fact]
+    public void Write_PathWithQuadCurve_ProducesSvgQuadCommand()
+    {
+        var path = new SKPath();
+        path.MoveTo(0f, 0f);
+        path.QuadTo(5f, 10f, 10f, 0f);
+
+        var json = JsonSerializer.Serialize(path, Options);
+
+        json.Should().Contain("Q");
+    }
+
+    // Read
+    [Fact]
+    public void Read_EmptyString_ReturnsEmptyPath()
+    {
+        var result = JsonSerializer.Deserialize<SKPath>("\"\"", Options);
+
+        result.Should().NotBeNull();
+        result.IsEmpty.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Read_SimpleSvgMoveTo_ProducesPathWithCorrectPoint()
+    {
+        var result = JsonSerializer.Deserialize<SKPath>("\"M 10 20\"", Options);
+
+        result.Should().NotBeNull();
+        result.GetPoint(0).Should().Be(new SKPoint(10f, 20f));
+    }
+
+    [Fact]
+    public void Read_SvgMoveAndLine_ProducesPathWithTwoPoints()
+    {
+        var result = JsonSerializer.Deserialize<SKPath>("\"M 0 0 L 10 10\"", Options);
+
+        result.Should().NotBeNull();
+        result.PointCount.Should().Be(2);
+    }
+
+    // Round-trip
+    [Fact]
+    public void RoundTrip_EmptyPath_RemainsEmpty()
+    {
+        var original = new SKPath();
+
+        var json = JsonSerializer.Serialize(original, Options);
+        var result = JsonSerializer.Deserialize<SKPath>(json, Options);
+
+        result.Should().NotBeNull();
+        result.IsEmpty.Should().BeTrue();
+    }
+
+    [Fact]
+    public void RoundTrip_PathWithLine_PointsArePreserved()
+    {
+        var original = new SKPath();
+        original.MoveTo(0f, 0f);
+        original.LineTo(100f, 50f);
+
+        var json = JsonSerializer.Serialize(original, Options);
+        var result = JsonSerializer.Deserialize<SKPath>(json, Options);
+
+        result.Should().NotBeNull();
+        result.PointCount.Should().Be(original.PointCount);
+        result.GetPoint(0).Should().Be(original.GetPoint(0));
+        result.GetPoint(1).Should().Be(original.GetPoint(1));
+    }
+
+    [Fact]
+    public void RoundTrip_ComplexPath_SvgDataIsPreserved()
+    {
+        // Compare SVG strings rather than PointCount: Close() inserts an implicit
+        // closing point that causes PointCount to differ after deserialization.
+        var original = new SKPath();
+        original.MoveTo(0f, 0f);
+        original.LineTo(50f, 0f);
+        original.QuadTo(75f, 50f, 50f, 100f);
+        original.LineTo(0f, 100f);
+        original.Close();
+
+        var json = JsonSerializer.Serialize(original, Options);
+        var result = JsonSerializer.Deserialize<SKPath>(json, Options);
+
+        result.Should().NotBeNull();
+        result.ToSvgPathData().Should().Be(original.ToSvgPathData());
+    }
+}

--- a/Scribble.Tests/HeadlessApp.axaml
+++ b/Scribble.Tests/HeadlessApp.axaml
@@ -1,0 +1,4 @@
+<Application xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="Scribble.Tests.HeadlessApp">
+</Application>

--- a/Scribble.Tests/HeadlessApp.axaml.cs
+++ b/Scribble.Tests/HeadlessApp.axaml.cs
@@ -1,0 +1,12 @@
+using Avalonia;
+using Avalonia.Markup.Xaml;
+
+namespace Scribble.Tests;
+
+public class HeadlessApp : Application
+{
+    public override void Initialize()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/Scribble.Tests/Lib/StrokePaintTests.cs
+++ b/Scribble.Tests/Lib/StrokePaintTests.cs
@@ -1,0 +1,131 @@
+using FluentAssertions;
+using Scribble.Shared.Lib;
+using SkiaSharp;
+
+namespace Scribble.Tests.Lib;
+
+public class StrokePaintTests
+{
+    [Fact]
+    public void ToSkPaint_ReturnsEquivalentSkPaint()
+    {
+        var strokePaint = new StrokePaint
+        {
+            StrokeCap = SKStrokeCap.Butt,
+            StrokeJoin = SKStrokeJoin.Round,
+            StrokeWidth = 4f,
+            IsAntialias = false,
+            Color = SKColors.Aqua
+        };
+
+        var skPaint = strokePaint.ToSkPaint();
+
+        skPaint.StrokeCap.Should().Be(strokePaint.StrokeCap);
+        skPaint.StrokeJoin.Should().Be(strokePaint.StrokeJoin);
+        skPaint.StrokeWidth.Should().Be(strokePaint.StrokeWidth);
+        skPaint.IsAntialias.Should().Be(strokePaint.IsAntialias);
+        skPaint.Color.Should().Be(strokePaint.Color);
+    }
+
+    [Fact]
+    public void ToSkPaint_SkPaintHasDashIntervals_ReturnsSkPaintWithNonNullPathEffect()
+    {
+        var strokePaint = new StrokePaint
+        {
+            StrokeCap = SKStrokeCap.Butt,
+            StrokeJoin = SKStrokeJoin.Round,
+            StrokeWidth = 4f,
+            IsAntialias = false,
+            Color = SKColors.Aqua,
+            DashIntervals = [1f, 2f, 3f, 4f]
+        };
+
+        var skPaint = strokePaint.ToSkPaint();
+
+        skPaint.PathEffect.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void GetCachedSkPaint_ReturnsSameCachedInstanceOnRepeatedCalls()
+    {
+        var strokePaint = new StrokePaint
+        {
+            StrokeCap = SKStrokeCap.Butt,
+            StrokeJoin = SKStrokeJoin.Round,
+            StrokeWidth = 4f,
+            IsAntialias = false,
+            Color = SKColors.Aqua
+        };
+
+        var actual = strokePaint.GetCachedSkPaint();
+
+        var expected = strokePaint.GetCachedSkPaint();
+        actual.Should().BeSameAs(expected);
+    }
+
+    [Fact]
+    public void Clone_ReturnsDistinctInstance()
+    {
+        var strokePaint = new StrokePaint();
+
+        var clone = strokePaint.Clone();
+
+        clone.Should().NotBeSameAs(strokePaint);
+    }
+
+    [Fact]
+    public void Clone_CopiesAllProperties()
+    {
+        var strokePaint = new StrokePaint
+        {
+            IsAntialias = false,
+            IsStroke = false,
+            StrokeCap = SKStrokeCap.Square,
+            StrokeJoin = SKStrokeJoin.Bevel,
+            StrokeWidth = 8f,
+            TextSize = 24f,
+            Color = SKColors.Blue,
+            FillColor = SKColors.Green,
+            DashIntervals = [1f, 2f]
+        };
+
+        var clone = strokePaint.Clone();
+
+        clone.IsAntialias.Should().Be(strokePaint.IsAntialias);
+        clone.IsStroke.Should().Be(strokePaint.IsStroke);
+        clone.StrokeCap.Should().Be(strokePaint.StrokeCap);
+        clone.StrokeJoin.Should().Be(strokePaint.StrokeJoin);
+        clone.StrokeWidth.Should().Be(strokePaint.StrokeWidth);
+        clone.TextSize.Should().Be(strokePaint.TextSize);
+        clone.Color.Should().Be(strokePaint.Color);
+        clone.FillColor.Should().Be(strokePaint.FillColor);
+    }
+
+    [Fact]
+    public void Clone_DashIntervals_IsDeepCopied()
+    {
+        var strokePaint = new StrokePaint
+        {
+            DashIntervals = [1f, 2f, 3f, 4f]
+        };
+
+        var clone = strokePaint.Clone();
+
+        clone.DashIntervals.Should().NotBeSameAs(strokePaint.DashIntervals);
+        clone.DashIntervals.Should().BeEquivalentTo(strokePaint.DashIntervals);
+    }
+
+    [Fact]
+    public void Clone_MutatingDashIntervals_DoesNotAffectOriginal()
+    {
+        var strokePaint = new StrokePaint
+        {
+            DashIntervals = [1f, 2f, 3f, 4f]
+        };
+
+        var clone = strokePaint.Clone();
+        clone.DashIntervals![0] = 99f;
+
+        strokePaint.DashIntervals![0].Should().Be(1f);
+    }
+}

--- a/Scribble.Tests/LibTests/MultiUserDrawingRoomTests.cs
+++ b/Scribble.Tests/LibTests/MultiUserDrawingRoomTests.cs
@@ -1,0 +1,56 @@
+using FluentAssertions;
+using Scribble.Services.MultiUserDrawing;
+using Scribble.Shared.Lib;
+
+namespace Scribble.Tests.LibTests;
+
+public class MultiUserDrawingRoomTests
+{
+    private static MultiUserDrawingClient Client(string id) =>
+        new(id, $"User-{id}");
+
+    // IsHost
+    [Fact]
+    public void IsHost_EmptyClientList_ReturnsFalse()
+    {
+        var room = new MultiUserDrawingRoom("room1", "conn-A", "Alice")
+        {
+            Clients = []
+        };
+
+        room.IsHost.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsHost_ClientIsFirstInList_ReturnsTrue()
+    {
+        var room = new MultiUserDrawingRoom("room1", "conn-A", "Alice")
+        {
+            Clients = [Client("conn-A"), Client("conn-B")]
+        };
+
+        room.IsHost.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsHost_ClientIsNotFirstInList_ReturnsFalse()
+    {
+        var room = new MultiUserDrawingRoom("room1", "conn-B", "Bob")
+        {
+            Clients = [Client("conn-A"), Client("conn-B")]
+        };
+
+        room.IsHost.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsHost_SingleClientAndItIsMe_ReturnsTrue()
+    {
+        var room = new MultiUserDrawingRoom("room1", "conn-A", "Alice")
+        {
+            Clients = [Client("conn-A")]
+        };
+
+        room.IsHost.Should().BeTrue();
+    }
+}

--- a/Scribble.Tests/LibTests/StrokePaintTests.cs
+++ b/Scribble.Tests/LibTests/StrokePaintTests.cs
@@ -2,7 +2,7 @@ using FluentAssertions;
 using Scribble.Shared.Lib;
 using SkiaSharp;
 
-namespace Scribble.Tests.Lib;
+namespace Scribble.Tests.LibTests;
 
 public class StrokePaintTests
 {

--- a/Scribble.Tests/Scribble.Tests.csproj
+++ b/Scribble.Tests/Scribble.Tests.csproj
@@ -18,6 +18,10 @@
         <PackageReference Include="FluentAssertions" />
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="NSubstitute" />
+        <PackageReference Include="NSubstitute.Analyzers.CSharp">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
         <PackageReference Include="xunit.runner.visualstudio"/>
         <PackageReference Include="xunit.v3"/>
     </ItemGroup>

--- a/Scribble.Tests/Scribble.Tests.csproj
+++ b/Scribble.Tests/Scribble.Tests.csproj
@@ -14,6 +14,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <PackageReference Include="Avalonia.Headless.XUnit" />
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="FluentAssertions" />
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>

--- a/Scribble.Tests/Scribble.Tests.csproj
+++ b/Scribble.Tests/Scribble.Tests.csproj
@@ -1,0 +1,29 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net9.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Scribble.Shared\Scribble.Shared.csproj"/>
+        <ProjectReference Include="..\Scribble\Scribble.csproj"/>
+        <ProjectReference Include="..\Scribble.Server\Scribble.Server.csproj"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector"/>
+        <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+        <PackageReference Include="NSubstitute" />
+        <PackageReference Include="xunit.runner.visualstudio"/>
+        <PackageReference Include="xunit.v3"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit"/>
+    </ItemGroup>
+
+</Project>

--- a/Scribble.Tests/ServiceTests/AutoSaveServiceTests.cs
+++ b/Scribble.Tests/ServiceTests/AutoSaveServiceTests.cs
@@ -1,0 +1,141 @@
+using FluentAssertions;
+using NSubstitute;
+using Scribble.Services.AutoSaveService;
+using Scribble.Services.CanvasStateService;
+using Scribble.Services.DocumentService;
+using Scribble.Services.MultiUserDrawing;
+using Scribble.Shared.Lib;
+
+namespace Scribble.Tests.ServiceTests;
+
+public class AutoSaveServiceTests : IDisposable
+{
+    private readonly AutoSaveService _autoSaveService;
+    private readonly ICanvasStateService _canvasStateService;
+    private readonly IDocumentService _documentService;
+    private readonly IMultiUserDrawingService _multiUserDrawingService;
+    private readonly string _tempDir;
+
+    // Fast timers so tests complete in milliseconds rather than seconds
+    private static readonly TimeSpan DebounceDelay = TimeSpan.FromMilliseconds(100);
+    private static readonly TimeSpan MaxDelay = TimeSpan.FromMilliseconds(500);
+
+    // Wait long enough for the debounce to settle, but not so long the test is slow
+    private static readonly TimeSpan AfterDebounce = TimeSpan.FromMilliseconds(300);
+
+    public AutoSaveServiceTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+
+        _canvasStateService = Substitute.For<ICanvasStateService>();
+        _documentService = Substitute.For<IDocumentService>();
+        _multiUserDrawingService = Substitute.For<IMultiUserDrawingService>();
+
+        _autoSaveService = new AutoSaveService(
+            _canvasStateService, _documentService, _multiUserDrawingService,
+            customBaseDirectory: _tempDir,
+            debounceDelay: DebounceDelay,
+            maxDelay: MaxDelay);
+    }
+
+    private string AppDataPath => Path.Combine(_tempDir, "Scribble");
+    private string AutoSavedStateFilePath => Path.Combine(AppDataPath, "autosave.scribble");
+
+    [Fact]
+    public void DeleteAutoSavedState_FileExists_FileIsDeleted()
+    {
+        File.Create(AutoSavedStateFilePath).Dispose();
+        File.Exists(AutoSavedStateFilePath).Should().BeTrue();
+
+        _autoSaveService.DeleteAutoSavedState();
+
+        File.Exists(AutoSavedStateFilePath).Should().BeFalse();
+    }
+
+    [Fact]
+    public void DeleteAutoSavedState_FileDoesNotExist_NoExceptionThrown()
+    {
+        var act = () => _autoSaveService.DeleteAutoSavedState();
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Dispose_NoExceptionThrown()
+    {
+        var act = () => _autoSaveService.Dispose();
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Dispose_CalledTwice_NoExceptionThrown()
+    {
+        _autoSaveService.Dispose();
+        var act = () => _autoSaveService.Dispose();
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public async Task Dispose_WhileAutoSaveIsPending_CancelsAutoSave()
+    {
+        _canvasStateService.CanvasInvalidated += Raise.Event<Action>();
+        _autoSaveService.Dispose();
+
+        await Task.Delay(AfterDebounce, TestContext.Current.CancellationToken);
+
+        await _documentService.DidNotReceive().SaveAsync(Arg.Any<Stream>());
+    }
+
+    [Fact]
+    public async Task CanvasIsInvalidated_TriggersAutoSave()
+    {
+        _canvasStateService.CanvasInvalidated += Raise.Event<Action>();
+
+        await Task.Delay(AfterDebounce, TestContext.Current.CancellationToken);
+
+        await _documentService.Received().SaveAsync(Arg.Any<Stream>());
+        File.Exists(AutoSavedStateFilePath).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CanvasIsInvalidatedWhileInRoom_AutoSaveIsPaused()
+    {
+        var room = new MultiUserDrawingRoom("room1", "conn-A", "Alice")
+        {
+            Clients = [new MultiUserDrawingClient("conn-A", "Alice")]
+        };
+
+        _canvasStateService.CanvasInvalidated += Raise.Event<Action>();
+        _multiUserDrawingService.Room.Returns(room);
+        _multiUserDrawingService.RoomChanged += Raise.Event<Action<MultiUserDrawingRoom?>>(room);
+
+        await Task.Delay(AfterDebounce, TestContext.Current.CancellationToken);
+
+        await _documentService.DidNotReceive().SaveAsync(Arg.Any<Stream>());
+    }
+
+    [Fact]
+    public async Task RapidCanvasInvalidationsWithinDebounceWindow_OnlyOneSaveIsTriggered()
+    {
+        // Fire three invalidations back-to-back, each one cancels the previous debounce timer
+        _canvasStateService.CanvasInvalidated += Raise.Event<Action>();
+        _canvasStateService.CanvasInvalidated += Raise.Event<Action>();
+        _canvasStateService.CanvasInvalidated += Raise.Event<Action>();
+
+        // Wait for the debounce to settle after the final invalidation
+        await Task.Delay(AfterDebounce, TestContext.Current.CancellationToken);
+
+        await _documentService.Received(1).SaveAsync(Arg.Any<Stream>());
+    }
+
+    public void Dispose()
+    {
+        _autoSaveService.Dispose();
+        if (Directory.Exists(AppDataPath))
+        {
+            Directory.Delete(AppDataPath, true);
+        }
+    }
+}

--- a/Scribble.Tests/ServiceTests/CanvasStateServiceTests.cs
+++ b/Scribble.Tests/ServiceTests/CanvasStateServiceTests.cs
@@ -1,0 +1,529 @@
+using Avalonia.Skia;
+using FluentAssertions;
+using NSubstitute;
+using Scribble.Services.CanvasStateService;
+using Scribble.Services.MultiUserDrawing;
+using Scribble.Shared.Lib;
+using Scribble.Shared.Lib.CanvasElements;
+using Scribble.Shared.Lib.CanvasElements.Strokes;
+using SkiaSharp;
+
+namespace Scribble.Tests.ServiceTests;
+
+public class CanvasStateServiceTests
+{
+    private readonly IMultiUserDrawingService _multiUserDrawingService;
+    private readonly CanvasStateService _canvasStateService;
+
+    public CanvasStateServiceTests()
+    {
+        _multiUserDrawingService = Substitute.For<IMultiUserDrawingService>();
+        _multiUserDrawingService.Room.Returns((MultiUserDrawingRoom?)null);
+        _canvasStateService = new CanvasStateService(_multiUserDrawingService);
+    }
+
+    private static StrokePaint DefaultPaint() => new() { Color = SKColors.Black, StrokeWidth = 2f };
+
+    private static (Guid actionId, Guid strokeId) ApplyStartStroke(
+        CanvasStateService sut, SKPoint? startPoint = null)
+    {
+        var actionId = Guid.NewGuid();
+        var strokeId = Guid.NewGuid();
+        sut.ApplyEvent(new StartStrokeEvent(
+            actionId, strokeId, startPoint ?? new SKPoint(0f, 0f),
+            DefaultPaint(), ToolType.Pencil, []));
+        return (actionId, strokeId);
+    }
+
+    // StartStrokeEvent
+
+    [Fact]
+    public void ApplyEvent_StartStroke_CanvasElementsContainsOneElement()
+    {
+        ApplyStartStroke(_canvasStateService);
+
+        _canvasStateService.CanvasElements.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void ApplyEvent_StartStroke_HasEventsIsTrue()
+    {
+        ApplyStartStroke(_canvasStateService);
+
+        _canvasStateService.HasEvents.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ApplyEvent_StartStroke_GetSelectedElementsIsEmpty()
+    {
+        ApplyStartStroke(_canvasStateService);
+
+        _canvasStateService.GetSelectedElements().Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ApplyEvent_StartStroke_ElementIsDrawStroke()
+    {
+        ApplyStartStroke(_canvasStateService);
+
+        _canvasStateService.CanvasElements[0].Should().BeOfType<DrawStroke>();
+    }
+
+    [Fact]
+    public void ApplyEvent_StartStroke_StrokePaintColorMatchesEvent()
+    {
+        var paint = new StrokePaint { Color = SKColors.Red, StrokeWidth = 5f };
+        var strokeId = Guid.NewGuid();
+        _canvasStateService.ApplyEvent(new StartStrokeEvent(
+            Guid.NewGuid(), strokeId, SKPoint.Empty, paint, ToolType.Pencil, []));
+
+        var stroke = (DrawStroke)_canvasStateService.CanvasElements[0];
+        stroke.Paint.Color.Should().Be(SKColors.Red);
+        stroke.Paint.StrokeWidth.Should().Be(5f);
+    }
+
+    // PencilStrokeLineToEvent
+
+    [Fact]
+    public void ApplyEvent_PencilStrokeLineTo_StrokePathHasAdditionalPoints()
+    {
+        var (_, strokeId) = ApplyStartStroke(_canvasStateService, new SKPoint(0f, 0f));
+
+        _canvasStateService.ApplyEvent(new PencilStrokeLineToEvent(Guid.NewGuid(), strokeId, new SKPoint(50f, 50f)));
+
+        var stroke = (DrawStroke)_canvasStateService.CanvasElements[0];
+        stroke.Path.PointCount.Should().BeGreaterThan(1);
+    }
+
+    [Fact]
+    public void ApplyEvent_MultiplePencilStrokeLineTo_PathPointCountGrowsWithEachPoint()
+    {
+        var (_, strokeId) = ApplyStartStroke(_canvasStateService, new SKPoint(0f, 0f));
+
+        _canvasStateService.ApplyEvent(new PencilStrokeLineToEvent(Guid.NewGuid(), strokeId, new SKPoint(10f, 10f)));
+        var countAfterFirst = ((DrawStroke)_canvasStateService.CanvasElements[0]).Path.PointCount;
+
+        _canvasStateService.ApplyEvent(new PencilStrokeLineToEvent(Guid.NewGuid(), strokeId, new SKPoint(20f, 20f)));
+        var countAfterSecond = ((DrawStroke)_canvasStateService.CanvasElements[0]).Path.PointCount;
+
+        countAfterSecond.Should().BeGreaterThanOrEqualTo(countAfterFirst);
+    }
+
+    // LineStrokeLineToEvent
+
+    [Fact]
+    public void ApplyEvent_LineStrokeLineTo_StrokePathContainsEndpoint()
+    {
+        var (_, strokeId) = ApplyStartStroke(_canvasStateService, new SKPoint(0f, 0f));
+        var endpoint = new SKPoint(200f, 100f);
+
+        _canvasStateService.ApplyEvent(new LineStrokeLineToEvent(Guid.NewGuid(), strokeId, endpoint));
+
+        var stroke = (DrawStroke)_canvasStateService.CanvasElements[0];
+        stroke.Path.Points.Should().Contain(p =>
+            Math.Abs(p.X - endpoint.X) < Math.Pow(10d, -5d) && Math.Abs(p.Y - endpoint.Y) < Math.Pow(10d, -5d));
+    }
+
+    // AddTextEvent
+
+    [Fact]
+    public void ApplyEvent_AddText_CanvasElementsContainsTextStroke()
+    {
+        var textId = Guid.NewGuid();
+        _canvasStateService.ApplyEvent(new AddTextEvent(
+            Guid.NewGuid(), textId,
+            new SKPoint(50f, 50f), "Hello",
+            new StrokePaint { TextSize = 24f }, []));
+
+        _canvasStateService.CanvasElements.Should().HaveCount(1);
+        _canvasStateService.CanvasElements[0].Should().BeOfType<TextStroke>();
+    }
+
+    [Fact]
+    public void ApplyEvent_AddText_TextStrokeTextMatchesEvent()
+    {
+        var textId = Guid.NewGuid();
+        _canvasStateService.ApplyEvent(new AddTextEvent(
+            Guid.NewGuid(), textId,
+            new SKPoint(0f, 0f), "Scribble",
+            new StrokePaint { TextSize = 16f }, []));
+
+        var textStroke = (TextStroke)_canvasStateService.CanvasElements[0];
+        textStroke.Text.Should().Be("Scribble");
+    }
+
+    [Fact]
+    public void ApplyEvent_AddText_TextStrokePositionMatchesEvent()
+    {
+        var position = new SKPoint(100f, 200f);
+        _canvasStateService.ApplyEvent(new AddTextEvent(
+            Guid.NewGuid(), Guid.NewGuid(),
+            position, "Hi",
+            new StrokePaint { TextSize = 12f }, []));
+
+        var textStroke = (TextStroke)_canvasStateService.CanvasElements[0];
+        textStroke.Position.X.Should().BeApproximately(position.X, precision: 0.01f);
+        textStroke.Position.Y.Should().BeApproximately(position.Y, precision: 0.01f);
+    }
+
+    // LoadCanvasEvent via LoadCanvas()
+
+    [Fact]
+    public void LoadCanvas_EmptyList_CanvasElementsIsEmpty()
+    {
+        ApplyStartStroke(_canvasStateService);
+
+        _canvasStateService.LoadCanvas([]);
+
+        _canvasStateService.CanvasElements.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void LoadCanvas_WithElements_CanvasElementsMatchCount()
+    {
+        var stroke1Id = Guid.NewGuid();
+        var stroke2Id = Guid.NewGuid();
+        var path = new SKPath();
+        path.MoveTo(0f, 0f);
+        path.LineTo(10f, 10f);
+
+        var elements = new List<CanvasElement>
+        {
+            new DrawStroke
+            {
+                Id = stroke1Id, ToolType = ToolType.Pencil, LayerIndex = 0,
+                Path = path.Clone(), Paint = DefaultPaint(), ToolOptions = []
+            },
+            new DrawStroke
+            {
+                Id = stroke2Id, ToolType = ToolType.Pencil, LayerIndex = 0,
+                Path = path.Clone(), Paint = DefaultPaint(), ToolOptions = []
+            }
+        };
+
+        _canvasStateService.LoadCanvas(elements);
+
+        _canvasStateService.CanvasElements.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void LoadCanvas_AfterStrokes_UndoStackIsCleared()
+    {
+        ApplyStartStroke(_canvasStateService);
+        _canvasStateService.ApplyEvent(new EndStrokeEvent(Guid.NewGuid()));
+
+        _canvasStateService.LoadCanvas([]);
+
+        _canvasStateService.CanUndo.Should().BeFalse();
+    }
+
+    [Fact]
+    public void LoadCanvas_AfterUndoableAction_RedoStackIsCleared()
+    {
+        ApplyStartStroke(_canvasStateService);
+        _canvasStateService.ApplyEvent(new EndStrokeEvent(Guid.NewGuid()));
+        _canvasStateService.Undo();
+
+        _canvasStateService.LoadCanvas([]);
+
+        _canvasStateService.CanRedo.Should().BeFalse();
+    }
+
+    // Undo / Redo
+    // All events in one stroke share the same ActionId
+    // The UndoEvent uses that ActionId to hide Start, LineTo, and End together during replay.
+
+    private static (Guid actionId, Guid strokeId) ApplyCompleteStroke(
+        CanvasStateService sut, SKPoint? start = null, SKPoint? end = null)
+    {
+        var actionId = Guid.NewGuid();
+        var strokeId = Guid.NewGuid();
+        sut.ApplyEvent(new StartStrokeEvent(
+            actionId, strokeId, start ?? SKPoint.Empty, DefaultPaint(), ToolType.Pencil, []));
+        sut.ApplyEvent(new PencilStrokeLineToEvent(actionId, strokeId, end ?? new SKPoint(50f, 50f)));
+        sut.ApplyEvent(new EndStrokeEvent(actionId));
+        return (actionId, strokeId);
+    }
+
+    [Fact]
+    public void CanUndo_AfterTerminalEvent_IsTrue()
+    {
+        ApplyCompleteStroke(_canvasStateService);
+
+        _canvasStateService.CanUndo.Should().BeTrue();
+    }
+
+    [Fact]
+    public void CanRedo_BeforeAnyUndo_IsFalse()
+    {
+        ApplyCompleteStroke(_canvasStateService);
+
+        _canvasStateService.CanRedo.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Undo_AfterOneStroke_CanvasElementsIsEmpty()
+    {
+        ApplyCompleteStroke(_canvasStateService);
+
+        _canvasStateService.Undo();
+
+        _canvasStateService.CanvasElements.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Undo_AfterOneStroke_CanRedoBecomesTrue()
+    {
+        ApplyCompleteStroke(_canvasStateService);
+
+        _canvasStateService.Undo();
+
+        _canvasStateService.CanRedo.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Undo_AfterOneStroke_CanUndoBecomesFalse()
+    {
+        ApplyCompleteStroke(_canvasStateService);
+
+        _canvasStateService.Undo();
+
+        _canvasStateService.CanUndo.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Redo_AfterUndo_CanvasElementsCountIsRestored()
+    {
+        ApplyCompleteStroke(_canvasStateService);
+        _canvasStateService.Undo();
+
+        _canvasStateService.Redo();
+
+        _canvasStateService.CanvasElements.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void Redo_AfterUndo_CanRedoBecomesFalse()
+    {
+        ApplyCompleteStroke(_canvasStateService);
+        _canvasStateService.Undo();
+
+        _canvasStateService.Redo();
+
+        _canvasStateService.CanRedo.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Undo_AfterTwoStrokes_OnlyFirstStrokeRemainsVisible()
+    {
+        ApplyCompleteStroke(_canvasStateService);
+        ApplyCompleteStroke(_canvasStateService);
+
+        _canvasStateService.Undo();
+
+        _canvasStateService.CanvasElements.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void Undo_WhenStackIsEmpty_DoesNotThrow()
+    {
+        var act = () => _canvasStateService.Undo();
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Redo_WhenStackIsEmpty_DoesNotThrow()
+    {
+        var act = () => _canvasStateService.Redo();
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Undo_WhenStackIsEmpty_CanvasElementsUnchanged()
+    {
+        ApplyCompleteStroke(_canvasStateService);
+
+        _canvasStateService.Undo(); // empties the stack
+        _canvasStateService.Undo(); // no-op
+
+        _canvasStateService.CanvasElements.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ApplyEvent_AfterUndo_ClearsRedoStack()
+    {
+        ApplyCompleteStroke(_canvasStateService);
+        _canvasStateService.Undo();
+
+        // Drawing a new stroke after an undo should wipe the redo stack
+        ApplyCompleteStroke(_canvasStateService);
+
+        _canvasStateService.CanRedo.Should().BeFalse();
+    }
+
+    // Erasing
+    // CheckAndErase marks a stroke as erased when the eraser point is inside Path.Contains()
+    // OR within 10px of the line segment between the path's first and last points.
+    // Placing the eraser exactly at the stroke's start point is a reliable hit.
+
+    private static (Guid actionId, Guid strokeId) ApplyCompleteStroke(
+        CanvasStateService sut, SKPoint start, SKPoint end)
+    {
+        var actionId = Guid.NewGuid();
+        var strokeId = Guid.NewGuid();
+        sut.ApplyEvent(new StartStrokeEvent(actionId, strokeId, start, DefaultPaint(), ToolType.Pencil, []));
+        sut.ApplyEvent(new PencilStrokeLineToEvent(actionId, strokeId, end));
+        sut.ApplyEvent(new EndStrokeEvent(actionId));
+        return (actionId, strokeId);
+    }
+
+    private static void ApplyCompleteErase(CanvasStateService sut, Guid strokeId, SKPoint erasePoint)
+    {
+        var actionId = Guid.NewGuid();
+        sut.ApplyEvent(new StartEraseStrokeEvent(actionId, strokeId, erasePoint));
+        sut.ApplyEvent(new TriggerEraseEvent(actionId, strokeId));
+    }
+
+    [Fact]
+    public void ApplyEvent_EraseAtStrokePosition_StrokeIsRemovedFromCanvas()
+    {
+        var strokeStart = new SKPoint(0f, 0f);
+        ApplyCompleteStroke(_canvasStateService, strokeStart, new SKPoint(100f, 0f));
+
+        ApplyCompleteErase(_canvasStateService, Guid.NewGuid(), strokeStart);
+
+        _canvasStateService.CanvasElements.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ApplyEvent_EraseInEmptySpace_CanvasElementsUnchanged()
+    {
+        ApplyCompleteStroke(_canvasStateService,
+            new SKPoint(500f, 500f), new SKPoint(600f, 500f));
+
+        // Erase far from the stroke — TriggerEraseEvent will have no targets and become stale
+        ApplyCompleteErase(_canvasStateService, Guid.NewGuid(), new SKPoint(0f, 0f));
+
+        _canvasStateService.CanvasElements.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void ApplyEvent_EraseInEmptySpace_CanUndoRemainsTrue()
+    {
+        ApplyCompleteStroke(_canvasStateService,
+            new SKPoint(500f, 500f), new SKPoint(600f, 500f));
+
+        ApplyCompleteErase(_canvasStateService, Guid.NewGuid(), new SKPoint(0f, 0f));
+
+        // Stale erase does not push onto the undo stack; the stroke's EndStroke is still top
+        _canvasStateService.CanUndo.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Undo_AfterSuccessfulErase_StrokeIsRestored()
+    {
+        var strokeStart = new SKPoint(0f, 0f);
+        ApplyCompleteStroke(_canvasStateService, strokeStart, new SKPoint(100f, 0f));
+        ApplyCompleteErase(_canvasStateService, Guid.NewGuid(), strokeStart);
+        _canvasStateService.CanvasElements.Should().BeEmpty();
+
+        _canvasStateService.Undo();
+
+        _canvasStateService.CanvasElements.Should().HaveCount(1);
+    }
+
+    // Selection
+    // CheckAndSelect requires the selection rect to completely contain the stroke's TightBounds.
+    // A rect from (0,0) -> (1000,1000) reliably encloses any stroke placed at modest coordinates.
+    // ActiveSelectionBoundId and SelectedElementIds are only updated for LOCAL bounds
+    // (bounds created with isLocalEvent: true, which is the default for ApplyEvent).
+
+    private static (Guid boundId, Guid actionId) ApplySelectionBound(
+        CanvasStateService sut, SKPoint from, SKPoint to)
+    {
+        var actionId = Guid.NewGuid();
+        var boundId = Guid.NewGuid();
+        sut.ApplyEvent(new CreateSelectionBoundEvent(actionId, boundId, from));
+        sut.ApplyEvent(new IncreaseSelectionBoundEvent(actionId, boundId, to));
+        sut.ApplyEvent(new EndSelectionEvent(actionId, boundId));
+        return (boundId, actionId);
+    }
+
+    [Fact]
+    public void ApplyEvent_CreateSelectionBound_ActiveSelectionBoundIdIsNotNull()
+    {
+        ApplyCompleteStroke(_canvasStateService,
+            new SKPoint(10f, 10f), new SKPoint(50f, 50f));
+
+        var (boundId, _) = ApplySelectionBound(_canvasStateService,
+            new SKPoint(0f, 0f), new SKPoint(1000f, 1000f));
+
+        _canvasStateService.ActiveSelectionBoundId.Should().Be(boundId);
+    }
+
+    [Fact]
+    public void ApplyEvent_SelectionBoundCoversStroke_SelectedElementIdsContainsStrokeId()
+    {
+        var (_, strokeId) = ApplyCompleteStroke(_canvasStateService,
+            new SKPoint(10f, 10f), new SKPoint(50f, 50f));
+
+        ApplySelectionBound(_canvasStateService,
+            new SKPoint(0f, 0f), new SKPoint(1000f, 1000f));
+
+        _canvasStateService.SelectedElementIds.Should().Contain(strokeId);
+    }
+
+    [Fact]
+    public void ApplyEvent_SelectionBoundCoversStroke_GetSelectedElementsReturnsStroke()
+    {
+        var (_, strokeId) = ApplyCompleteStroke(_canvasStateService,
+            new SKPoint(10f, 10f), new SKPoint(50f, 50f));
+
+        ApplySelectionBound(_canvasStateService,
+            new SKPoint(0f, 0f), new SKPoint(1000f, 1000f));
+
+        _canvasStateService.GetSelectedElements()
+            .Should().ContainSingle(e => e.Id == strokeId);
+    }
+
+    [Fact]
+    public void ApplyEvent_SelectionBoundDoesNotCoverStroke_SelectedElementIdsIsEmpty()
+    {
+        // Stroke is at (500,500), well outside the (0,0) -> (100,100) selection rect
+        ApplyCompleteStroke(_canvasStateService,
+            new SKPoint(500f, 500f), new SKPoint(600f, 500f));
+
+        ApplySelectionBound(_canvasStateService,
+            new SKPoint(0f, 0f), new SKPoint(100f, 100f));
+
+        _canvasStateService.SelectedElementIds.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ApplyEvent_ClearSelection_ActiveSelectionBoundIdIsNull()
+    {
+        ApplyCompleteStroke(_canvasStateService,
+            new SKPoint(10f, 10f), new SKPoint(50f, 50f));
+        ApplySelectionBound(_canvasStateService,
+            new SKPoint(0f, 0f), new SKPoint(1000f, 1000f));
+
+        _canvasStateService.ApplyEvent(new ClearSelectionEvent(Guid.NewGuid()));
+
+        _canvasStateService.ActiveSelectionBoundId.Should().BeNull();
+    }
+
+    [Fact]
+    public void ApplyEvent_ClearSelection_SelectedElementIdsIsEmpty()
+    {
+        ApplyCompleteStroke(_canvasStateService,
+            new SKPoint(10f, 10f), new SKPoint(50f, 50f));
+        ApplySelectionBound(_canvasStateService,
+            new SKPoint(0f, 0f), new SKPoint(1000f, 1000f));
+
+        _canvasStateService.ApplyEvent(new ClearSelectionEvent(Guid.NewGuid()));
+
+        _canvasStateService.SelectedElementIds.Should().BeEmpty();
+    }
+}

--- a/Scribble.Tests/ServiceTests/CanvasStateServiceTests.cs
+++ b/Scribble.Tests/ServiceTests/CanvasStateServiceTests.cs
@@ -526,4 +526,261 @@ public class CanvasStateServiceTests
 
         _canvasStateService.SelectedElementIds.Should().BeEmpty();
     }
+
+    // Selection: Transform operations
+    // These all go through the fast-path and require a bound + stroke already tracked
+    // in _selectionBoundLookup. ApplySelectionBound sets that up.
+
+    private static SKPoint GetStrokeMidpoint(CanvasStateService canvasStateService, Guid strokeId)
+    {
+        var stroke = (DrawStroke)canvasStateService.CanvasElements.First(e => e.Id == strokeId);
+        return new SKPoint(stroke.Path.TightBounds.MidX, stroke.Path.TightBounds.MidY);
+    }
+
+    [Fact]
+    public void ApplyEvent_MoveCanvasElements_StrokePathIsTranslated()
+    {
+        var (_, strokeId) = ApplyCompleteStroke(_canvasStateService,
+            new SKPoint(10f, 10f), new SKPoint(50f, 50f));
+        var (boundId, _) = ApplySelectionBound(_canvasStateService,
+            new SKPoint(0f, 0f), new SKPoint(1000f, 1000f));
+
+        var before = GetStrokeMidpoint(_canvasStateService, strokeId);
+        var delta = new SKPoint(100f, 50f);
+        _canvasStateService.ApplyEvent(new MoveCanvasElementsEvent(Guid.NewGuid(), boundId, delta));
+
+        var after = GetStrokeMidpoint(_canvasStateService, strokeId);
+        after.X.Should().BeApproximately(before.X + delta.X, precision: 1f);
+        after.Y.Should().BeApproximately(before.Y + delta.Y, precision: 1f);
+    }
+
+    [Fact]
+    public void ApplyEvent_RotateCanvasElements_StrokeBoundsRotateAroundCenter()
+    {
+        var (_, strokeId) = ApplyCompleteStroke(_canvasStateService,
+            new SKPoint(100f, 0f), new SKPoint(200f, 0f));
+        var (boundId, _) = ApplySelectionBound(_canvasStateService,
+            new SKPoint(0f, 0f), new SKPoint(1000f, 1000f));
+
+        var before = GetStrokeMidpoint(_canvasStateService, strokeId);
+        // Rotate 180° around the stroke midpoint, path should end up at approximately the same spot
+        // because it's rotating around its own centre, but let's just verify the path changed
+        var center = new SKPoint(150f, 0f);
+        _canvasStateService.ApplyEvent(new RotateCanvasElementsEvent(
+            Guid.NewGuid(), boundId, DegreesRad: MathF.PI, Center: center));
+
+        var after = GetStrokeMidpoint(_canvasStateService, strokeId);
+        // After 180° rotation around (150, 0), midpoint at (150, 0) stays at (150, 0)
+        after.X.Should().BeApproximately(before.X, precision: 1f);
+        after.Y.Should().BeApproximately(before.Y, precision: 1f);
+    }
+
+    [Fact]
+    public void ApplyEvent_ScaleCanvasElements_StrokeBoundsScaleAroundCenter()
+    {
+        var (_, strokeId) = ApplyCompleteStroke(_canvasStateService,
+            new SKPoint(100f, 100f), new SKPoint(200f, 100f));
+        var (boundId, _) = ApplySelectionBound(_canvasStateService,
+            new SKPoint(0f, 0f), new SKPoint(1000f, 1000f));
+
+        var stroke = (DrawStroke)_canvasStateService.CanvasElements.First(e => e.Id == strokeId);
+        var widthBefore = stroke.Path.TightBounds.Width;
+
+        // Scale by 2x around origin
+        _canvasStateService.ApplyEvent(new ScaleCanvasElementsEvent(
+            Guid.NewGuid(), boundId,
+            Scale: new SKPoint(2f, 2f),
+            Center: new SKPoint(0f, 0f)));
+
+        var widthAfter = stroke.Path.TightBounds.Width;
+        widthAfter.Should().BeApproximately(widthBefore * 2f, precision: 1f);
+    }
+
+    // Layer Management
+    // After replay, layer indices are normalized to contiguous 0..N-1.
+    // Two strokes created sequentially share layer 0, then normalization maps them both to 0.
+    // SetElementLayerEvent changes the raw value before normalization.
+    // NudgeElementLayerEvent adds an offset to the existing value.
+
+    [Fact]
+    public void ApplyEvent_SetElementLayer_ElementLayerIndexChanges()
+    {
+        var (_, strokeId) = ApplyCompleteStroke(_canvasStateService);
+
+        _canvasStateService.ApplyEvent(new SetElementLayerEvent(
+            Guid.NewGuid(), [strokeId], NewLayerIndex: 5));
+
+        // Only one element, so normalization maps layer 5 → 0
+        _canvasStateService.CanvasElements[0].LayerIndex.Should().Be(0);
+    }
+
+    [Fact]
+    public void ApplyEvent_SetElementLayer_ChangesRelativeOrder()
+    {
+        // stroke A created first (layer 0), stroke B second (also layer 0 at creation)
+        var (_, strokeA) = ApplyCompleteStroke(_canvasStateService,
+            new SKPoint(0f, 0f), new SKPoint(10f, 10f));
+        var (_, strokeB) = ApplyCompleteStroke(_canvasStateService,
+            new SKPoint(100f, 100f), new SKPoint(110f, 110f));
+
+        // Move A above B
+        _canvasStateService.ApplyEvent(new SetElementLayerEvent(
+            Guid.NewGuid(), [strokeA], NewLayerIndex: 10));
+
+        // After normalization: B stays at 0, A moves to 1
+        var elementA = _canvasStateService.CanvasElements.First(e => e.Id == strokeA);
+        var elementB = _canvasStateService.CanvasElements.First(e => e.Id == strokeB);
+        elementA.LayerIndex.Should().BeGreaterThan(elementB.LayerIndex);
+    }
+
+    [Fact]
+    public void ApplyEvent_NudgeElementLayer_ElementLayerIndexShifts()
+    {
+        var (_, strokeA) = ApplyCompleteStroke(_canvasStateService,
+            new SKPoint(0f, 0f), new SKPoint(10f, 10f));
+        var (_, strokeB) = ApplyCompleteStroke(_canvasStateService,
+            new SKPoint(100f, 100f), new SKPoint(110f, 110f));
+
+        // Nudge B up by 1
+        _canvasStateService.ApplyEvent(new NudgeElementLayerEvent(
+            Guid.NewGuid(), [strokeB], Offset: 1));
+
+        var elementA = _canvasStateService.CanvasElements.First(e => e.Id == strokeA);
+        var elementB = _canvasStateService.CanvasElements.First(e => e.Id == strokeB);
+        elementB.LayerIndex.Should().BeGreaterThan(elementA.LayerIndex);
+    }
+
+    [Fact]
+    public void LayerNormalization_IndicesAreContiguousStartingFromZero()
+    {
+        var (_, strokeA) = ApplyCompleteStroke(_canvasStateService,
+            new SKPoint(0f, 0f), new SKPoint(10f, 10f));
+        var (_, strokeB) = ApplyCompleteStroke(_canvasStateService,
+            new SKPoint(100f, 100f), new SKPoint(110f, 110f));
+
+        // Set A to layer 100, far above B
+        _canvasStateService.ApplyEvent(new SetElementLayerEvent(
+            Guid.NewGuid(), [strokeA], NewLayerIndex: 100));
+
+        var layers = _canvasStateService.CanvasElements
+            .Select(e => e.LayerIndex)
+            .OrderBy(l => l)
+            .ToList();
+
+        // Should be [0, 1] not [0, 100]
+        layers.Should().BeEquivalentTo([0, 1]);
+    }
+
+    // Canvas Lifecycle, Events and BackgroundColor
+
+    [Fact]
+    public void SetBackgroundColor_ChangesBackgroundColor()
+    {
+        _canvasStateService.SetBackgroundColor(SKColors.Red);
+
+        _canvasStateService.BackgroundColor.Should().Be(SKColors.Red);
+    }
+
+    [Fact]
+    public void SetBackgroundColor_SameColor_DoesNotFireEvent()
+    {
+        var defaultColor = _canvasStateService.BackgroundColor;
+        var fired = false;
+        _canvasStateService.BackgroundColorChanged += () => fired = true;
+
+        _canvasStateService.SetBackgroundColor(defaultColor);
+
+        fired.Should().BeFalse();
+    }
+
+    [Fact]
+    public void SetBackgroundColor_DifferentColor_FiresBackgroundColorChanged()
+    {
+        var fired = false;
+        _canvasStateService.BackgroundColorChanged += () => fired = true;
+
+        _canvasStateService.SetBackgroundColor(SKColors.Green);
+
+        fired.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ApplyEvent_StartStroke_FiresCanvasInvalidated()
+    {
+        var fired = false;
+        _canvasStateService.CanvasInvalidated += () => fired = true;
+
+        ApplyStartStroke(_canvasStateService);
+
+        fired.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Undo_FiresUndoRedoStateChanged()
+    {
+        ApplyCompleteStroke(_canvasStateService);
+        var fired = false;
+        _canvasStateService.UndoRedoStateChanged += () => fired = true;
+
+        _canvasStateService.Undo();
+
+        fired.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Redo_FiresUndoRedoStateChanged()
+    {
+        ApplyCompleteStroke(_canvasStateService);
+        _canvasStateService.Undo();
+        var fired = false;
+        _canvasStateService.UndoRedoStateChanged += () => fired = true;
+
+        _canvasStateService.Redo();
+
+        fired.Should().BeTrue();
+    }
+
+    // Network Integration
+    // ApplyEvent stamps CreatorConnectionId and calls BroadcastEventAsync when Room is non-null.
+
+    private static MultiUserDrawingRoom MakeRoom(string connectionId = "conn-1") =>
+        new MultiUserDrawingRoom("room-1", connectionId, "Alice")
+        {
+            Clients = [new MultiUserDrawingClient(connectionId, "Alice")]
+        };
+
+    [Fact]
+    public async Task ApplyEvent_WhenRoomIsNull_BroadcastEventAsyncIsNotCalled()
+    {
+        _multiUserDrawingService.Room.Returns((MultiUserDrawingRoom?)null);
+
+        ApplyStartStroke(_canvasStateService);
+
+        await _multiUserDrawingService.DidNotReceive().BroadcastEventAsync(Arg.Any<Event>());
+    }
+
+    [Fact]
+    public async Task ApplyEvent_WhenRoomIsNonNull_BroadcastEventAsyncIsCalled()
+    {
+        var room = MakeRoom();
+        _multiUserDrawingService.Room.Returns(room);
+
+        ApplyStartStroke(_canvasStateService);
+
+        await _multiUserDrawingService.Received(1).BroadcastEventAsync(Arg.Any<Event>());
+    }
+
+    [Fact]
+    public async Task ApplyEvent_WhenInRoom_CreatorConnectionIdIsStampedOnEvent()
+    {
+        const string myConnectionId = "conn-abc";
+        var room = MakeRoom(myConnectionId);
+        _multiUserDrawingService.Room.Returns(room);
+
+        _canvasStateService.ApplyEvent(new StartStrokeEvent(
+            Guid.NewGuid(), Guid.NewGuid(), SKPoint.Empty, DefaultPaint(), ToolType.Pencil, []));
+
+        await _multiUserDrawingService.Received(1).BroadcastEventAsync(
+            Arg.Is<Event>(e => e.CreatorConnectionId == myConnectionId));
+    }
 }

--- a/Scribble.Tests/ServiceTests/DocumentServiceTests.cs
+++ b/Scribble.Tests/ServiceTests/DocumentServiceTests.cs
@@ -1,0 +1,215 @@
+using System.Text;
+using System.Text.Json;
+using Avalonia.Headless.XUnit;
+using FluentAssertions;
+using NSubstitute;
+using Scribble.Services.CanvasStateService;
+using Scribble.Services.DocumentService;
+using Scribble.Shared.Lib;
+using Scribble.Shared.Lib.CanvasElements;
+using Scribble.Shared.Lib.CanvasElements.Strokes;
+using SkiaSharp;
+
+namespace Scribble.Tests.ServiceTests;
+
+public class DocumentServiceTests
+{
+    private readonly IDocumentService _documentService;
+    private readonly ICanvasStateService _canvasStateService;
+
+    public DocumentServiceTests()
+    {
+        _canvasStateService = Substitute.For<ICanvasStateService>();
+        _documentService = new DocumentService(_canvasStateService);
+    }
+
+    private static DrawStroke MakeStroke(SKColor? color = null)
+    {
+        var path = new SKPath();
+        path.MoveTo(0f, 0f);
+        path.LineTo(100f, 50f);
+
+        return new DrawStroke
+        {
+            Id = Guid.NewGuid(),
+            ToolType = ToolType.Pencil,
+            LayerIndex = 0,
+            Path = path,
+            Paint = new StrokePaint { Color = color ?? SKColors.Red, StrokeWidth = 3f },
+            ToolOptions = []
+        };
+    }
+
+    private static CanvasImage MakeImage()
+    {
+        const string base64String = "BASE64_ENCODED_IMAGE_DATA";
+        return new CanvasImage
+        {
+            ImageBase64String = base64String,
+            Bounds = SKRect.Create(0f, 0f, 100f, 100f)
+        };
+    }
+
+    private static MemoryStream MakeStream(string json) =>
+        new(Encoding.UTF8.GetBytes(json));
+
+    // SaveAsync
+
+    [AvaloniaFact]
+    public async Task SaveAsync_CanvasHasStrokes_StreamContainsValidJSON()
+    {
+        var stroke = MakeStroke();
+        _canvasStateService.CanvasElements.Returns([stroke]);
+        _canvasStateService.BackgroundColor.Returns(SKColors.White);
+        using var stream = new MemoryStream();
+
+        await _documentService.SaveAsync(stream);
+
+        stream.Position = 0;
+        using var jsonDoc = await JsonDocument.ParseAsync(stream);
+        var root = jsonDoc.RootElement;
+
+        root.GetProperty("elements").GetProperty("strokes").GetArrayLength()
+            .Should().Be(1);
+    }
+
+    [AvaloniaFact]
+    public async Task SaveAsync_CanvasHasImages_StreamContainsValidJSON()
+    {
+        var image = MakeImage();
+        _canvasStateService.CanvasElements.Returns([image]);
+        _canvasStateService.BackgroundColor.Returns(SKColors.White);
+        using var stream = new MemoryStream();
+
+        await _documentService.SaveAsync(stream);
+
+        stream.Position = 0;
+        using var jsonDoc = await JsonDocument.ParseAsync(stream);
+        var root = jsonDoc.RootElement;
+
+        root.GetProperty("elements").GetProperty("images").GetArrayLength()
+            .Should().Be(1);
+        root.GetProperty("files").GetPropertyCount().Should().Be(1);
+    }
+
+    [AvaloniaFact]
+    public async Task SaveAsync_CanvasHasDuplicateImages_NoDuplicateFilesInJSON()
+    {
+        var image = MakeImage();
+        _canvasStateService.CanvasElements.Returns([image, image]);
+        _canvasStateService.BackgroundColor.Returns(SKColors.White);
+        using var stream = new MemoryStream();
+
+        await _documentService.SaveAsync(stream);
+
+        stream.Position = 0;
+        using var jsonDoc = await JsonDocument.ParseAsync(stream);
+        var root = jsonDoc.RootElement;
+
+        root.GetProperty("elements").GetProperty("images").GetArrayLength()
+            .Should().Be(2);
+        root.GetProperty("files").GetPropertyCount().Should().Be(1);
+    }
+
+    [AvaloniaFact]
+    public async Task SaveAsync_BackgroundColorIsSaved()
+    {
+        _canvasStateService.BackgroundColor.Returns(SKColors.Red);
+        using var stream = new MemoryStream();
+
+        await _documentService.SaveAsync(stream);
+
+        stream.Position = 0;
+        using var jsonDoc = await JsonDocument.ParseAsync(stream);
+        var root = jsonDoc.RootElement;
+
+        root.GetProperty("backgroundColor").GetString().Should().Be(SKColors.Red.ToString());
+    }
+
+    // LoadAsync
+
+    [AvaloniaFact]
+    public async Task LoadAsync_ValidJSONStream_CallsLoadCanvasWithCorrectElements()
+    {
+        var stroke = MakeStroke();
+        _canvasStateService.CanvasElements.Returns([stroke]);
+        using var stream = new MemoryStream();
+        await _documentService.SaveAsync(stream);
+        stream.Position = 0;
+
+        await _documentService.LoadAsync(stream);
+
+        _canvasStateService.Received(1).LoadCanvas(Arg.Is<List<CanvasElement>>(list => list.Count == 1));
+    }
+
+    [AvaloniaFact]
+    public async Task LoadAsync_ValidJSONStream_CallsSetBackgroundColor()
+    {
+        _canvasStateService.BackgroundColor.Returns(SKColors.Blue);
+        using var saveStream = new MemoryStream();
+        await _documentService.SaveAsync(saveStream);
+        saveStream.Position = 0;
+
+        await _documentService.LoadAsync(saveStream);
+
+        _canvasStateService.Received(1).SetBackgroundColor(SKColors.Blue);
+    }
+
+    [AvaloniaFact]
+    public async Task LoadAsync_MissingElementsKey_ThrowsException()
+    {
+        using var stream = MakeStream("""{ "files": {}, "backgroundColor": "#FF000000" }""");
+
+        var act = async () => await _documentService.LoadAsync(stream);
+
+        await act.Should().ThrowAsync<Exception>().WithMessage("*elements*");
+    }
+
+    [AvaloniaFact]
+    public async Task LoadAsync_MissingStrokesKey_ThrowsException()
+    {
+        using var stream = MakeStream("""
+                                      {
+                                          "elements": { "images": [] },
+                                          "files": {},
+                                          "backgroundColor": "#FF000000"
+                                      }
+                                      """);
+
+        var act = async () => await _documentService.LoadAsync(stream);
+
+        await act.Should().ThrowAsync<Exception>().WithMessage("*strokes*");
+    }
+
+    [AvaloniaFact]
+    public async Task LoadAsync_MissingFilesKey_ThrowsException()
+    {
+        using var stream = MakeStream("""
+                                      {
+                                          "elements": { "strokes": [], "images": [] },
+                                          "backgroundColor": "#FF000000"
+                                      }
+                                      """);
+
+        var act = async () => await _documentService.LoadAsync(stream);
+
+        await act.Should().ThrowAsync<Exception>().WithMessage("*files*");
+    }
+
+    [AvaloniaFact]
+    public async Task RoundTrip_SaveThenLoad_StrokeCountIsPreserved()
+    {
+        var stroke1 = MakeStroke(SKColors.Red);
+        var stroke2 = MakeStroke(SKColors.Blue);
+        _canvasStateService.CanvasElements.Returns([stroke1, stroke2]);
+        _canvasStateService.BackgroundColor.Returns(SKColors.Black);
+
+        using var stream = new MemoryStream();
+        await _documentService.SaveAsync(stream);
+        stream.Position = 0;
+        await _documentService.LoadAsync(stream);
+
+        _canvasStateService.Received(1).LoadCanvas(
+            Arg.Is<List<CanvasElement>>(list => list.Count == 2));
+    }
+}

--- a/Scribble.Tests/StateTests/CameraStateTests.cs
+++ b/Scribble.Tests/StateTests/CameraStateTests.cs
@@ -1,0 +1,180 @@
+using FluentAssertions;
+using Scribble.State;
+using SkiaSharp;
+
+namespace Scribble.Tests.StateTests;
+
+public class CameraStateTests
+{
+    public CameraStateTests()
+    {
+        // Reset camera state before each test
+        CameraState.Reset();
+    }
+
+    // SetZoom
+    [Fact]
+    public void SetZoom_ValueWithinRange_ZoomIsUpdated()
+    {
+        const float validZoom = 2.5f;
+        CameraState.SetZoom(validZoom);
+
+        CameraState.Zoom.Should().Be(validZoom);
+    }
+
+    [Fact]
+    public void SetZoom_ValueBelowRange_ZoomIsClampedToMinimum()
+    {
+        const float invalidZoom = 0.01f;
+        CameraState.SetZoom(invalidZoom);
+
+        CameraState.Zoom.Should().Be(CameraState.MinZoom);
+    }
+
+    [Fact]
+    public void SetZoom_ValueAboveRange_ZoomIsClampedToMaximum()
+    {
+        const float invalidZoom = 100f;
+        CameraState.SetZoom(invalidZoom);
+
+        CameraState.Zoom.Should().Be(CameraState.MaxZoom);
+    }
+
+    [Fact]
+    public void Reset_ResetsZoomToDefault()
+    {
+        CameraState.SetZoom(2.5f);
+        CameraState.Reset();
+
+        const float defaultZoom = 1.0f;
+        CameraState.Zoom.Should().Be(defaultZoom);
+    }
+
+    // ScreenToWorld
+    [Fact]
+    public void ScreenToWorld_NoZoomNoOffset_ScreenPosShouldEqualWorldPos()
+    {
+        var screenPos = new SKPoint(100, 100);
+
+        CameraState.ScreenToWorld(screenPos).Should().Be(screenPos);
+    }
+
+    [Fact]
+    public void ScreenToWorld_2xZoomNoOffset_WorldPosShouldBeHalved()
+    {
+        CameraState.SetZoom(2);
+        var screenPos = new SKPoint(100, 100);
+        CameraState.ScreenToWorld(screenPos).Should().Be(new SKPoint(screenPos.X / 2, screenPos.Y / 2));
+    }
+
+    [Fact]
+    public void ScreenToWorld_WithOffset_WorldPosShouldBeOffset()
+    {
+        var offset = new SKPoint(50, 75);
+        CameraState.WorldOffSetX = offset.X;
+        CameraState.WorldOffSetY = offset.Y;
+        var screenPos = new SKPoint(100, 100);
+
+        CameraState.ScreenToWorld(screenPos).Should().Be(screenPos + offset);
+    }
+
+    // WorldToScreen
+    [Fact]
+    public void WorldToScreen_NoZoomNoOffset_WorldPosShouldEqualScreenPos()
+    {
+        var worldPos = new SKPoint(100, 100);
+
+        CameraState.WorldToScreen(worldPos).Should().Be(worldPos);
+    }
+
+    [Fact]
+    public void WorldToScreen_2xZoomNoOffset_ScreenPosShouldBeDoubled()
+    {
+        CameraState.SetZoom(2);
+        var worldPos = new SKPoint(100, 100);
+
+        CameraState.WorldToScreen(worldPos).Should().Be(new SKPoint(worldPos.X * 2, worldPos.Y * 2));
+    }
+
+    [Fact]
+    public void WorldToScreen_WithOffset_ScreenPosShouldBeShiftedByOffset()
+    {
+        var offset = new SKPoint(50, 75);
+        CameraState.WorldOffSetX = offset.X;
+        CameraState.WorldOffSetY = offset.Y;
+        var worldPos = new SKPoint(100, 100);
+
+        CameraState.WorldToScreen(worldPos).Should().Be(worldPos - offset);
+    }
+
+    // GetViewMatrix
+    [Fact]
+    public void GetViewMatrix_DefaultState_ReturnsIdentityScaleAndZeroTranslation()
+    {
+        var matrix = CameraState.GetViewMatrix();
+
+        matrix.ScaleX.Should().Be(1f);
+        matrix.ScaleY.Should().Be(1f);
+        matrix.TransX.Should().Be(0f);
+        matrix.TransY.Should().Be(0f);
+    }
+
+    [Fact]
+    public void GetViewMatrix_2xZoomNoOffset_ScaleComponentsAreDoubled()
+    {
+        CameraState.SetZoom(2f);
+
+        var matrix = CameraState.GetViewMatrix();
+
+        matrix.ScaleX.Should().Be(2f);
+        matrix.ScaleY.Should().Be(2f);
+    }
+
+    [Fact]
+    public void GetViewMatrix_2xZoomNoOffset_TranslationRemainsZero()
+    {
+        CameraState.SetZoom(2f);
+
+        var matrix = CameraState.GetViewMatrix();
+
+        matrix.TransX.Should().Be(0f);
+        matrix.TransY.Should().Be(0f);
+    }
+
+    [Fact]
+    public void GetViewMatrix_WithOffsetNoZoom_ScaleRemainsIdentity()
+    {
+        CameraState.WorldOffSetX = 50f;
+        CameraState.WorldOffSetY = 75f;
+
+        var matrix = CameraState.GetViewMatrix();
+
+        matrix.ScaleX.Should().Be(1f);
+        matrix.ScaleY.Should().Be(1f);
+    }
+
+    [Fact]
+    public void GetViewMatrix_WithOffsetNoZoom_TranslationIsNegatedOffset()
+    {
+        CameraState.WorldOffSetX = 50f;
+        CameraState.WorldOffSetY = 75f;
+
+        var matrix = CameraState.GetViewMatrix();
+
+        matrix.TransX.Should().Be(-50f);
+        matrix.TransY.Should().Be(-75f);
+    }
+
+    [Fact]
+    public void GetViewMatrix_2xZoomWithOffset_TranslationIsNegatedAndOffsetScaledByZoom()
+    {
+        CameraState.SetZoom(2f);
+        CameraState.WorldOffSetX = 50f;
+        CameraState.WorldOffSetY = 75f;
+
+        var matrix = CameraState.GetViewMatrix();
+
+        matrix.TransX.Should().Be(-100f);
+        matrix.TransY.Should().Be(-150f);
+    }
+}

--- a/Scribble.Tests/StateTests/SelectionTests.cs
+++ b/Scribble.Tests/StateTests/SelectionTests.cs
@@ -1,0 +1,207 @@
+using FluentAssertions;
+using Scribble.State;
+using SkiaSharp;
+
+namespace Scribble.Tests.StateTests;
+
+public class SelectionTests
+{
+    // RefreshSelectionCenter
+    [Fact]
+    public void RefreshSelectionCenter_SquareBounds_CenterIsMiddleOfBounds()
+    {
+        var selection = new Selection
+        {
+            SelectionBounds = SKRect.Create(0f, 0f, 100f, 100f)
+        };
+
+        selection.RefreshSelectionCenter();
+
+        selection.SelectionCenter.Should().Be(new SKPoint(50f, 50f));
+    }
+
+    [Fact]
+    public void RefreshSelectionCenter_RectangularBounds_CenterIsMiddleOfBounds()
+    {
+        var selection = new Selection
+        {
+            SelectionBounds = SKRect.Create(10f, 20f, 80f, 40f)
+        };
+
+        selection.RefreshSelectionCenter();
+
+        selection.SelectionCenter.Should().Be(new SKPoint(50f, 40f));
+    }
+
+    [Fact]
+    public void RefreshSelectionCenter_BoundsNotAtOrigin_CenterAccountsForOffset()
+    {
+        var selection = new Selection
+        {
+            SelectionBounds = SKRect.Create(100f, 200f, 50f, 50f)
+        };
+
+        selection.RefreshSelectionCenter();
+
+        selection.SelectionCenter.Should().Be(new SKPoint(125f, 225f));
+    }
+
+    // UpdateSelectionRotationAngle
+    [Fact]
+    public void UpdateSelectionRotationAngle_ReferencePointDirectlyRight_AngleIsZero()
+    {
+        var selection = new Selection
+        {
+            SelectionCenter = new SKPoint(0f, 0f)
+        };
+
+        selection.UpdateSelectionRotationAngle(new SKPoint(1f, 0f));
+
+        selection.SelectionRotationAngle.Should().BeApproximately(0.0, 1e-10);
+    }
+
+    [Fact]
+    public void UpdateSelectionRotationAngle_ReferencePointDirectlyAbove_AngleIsNegativeHalfPi()
+    {
+        // In screen space Y increases downward, so a point directly above the
+        // center (lower Y) produces a negative Atan2 result.
+        var selection = new Selection
+        {
+            SelectionCenter = new SKPoint(0f, 0f)
+        };
+
+        selection.UpdateSelectionRotationAngle(new SKPoint(0f, -1f));
+
+        selection.SelectionRotationAngle.Should().BeApproximately(-Math.PI / 2, 1e-10);
+    }
+
+    [Fact]
+    public void UpdateSelectionRotationAngle_ReferencePointDirectlyBelow_AngleIsPositiveHalfPi()
+    {
+        var selection = new Selection
+        {
+            SelectionCenter = new SKPoint(0f, 0f)
+        };
+
+        selection.UpdateSelectionRotationAngle(new SKPoint(0f, 1f));
+
+        selection.SelectionRotationAngle.Should().BeApproximately(Math.PI / 2, 1e-10);
+    }
+
+    [Fact]
+    public void UpdateSelectionRotationAngle_ReferencePointIsCenter_AngleIsZero()
+    {
+        // Atan2(0, 0) is defined as 0 in .NET
+        var selection = new Selection
+        {
+            SelectionCenter = new SKPoint(50f, 50f)
+        };
+
+        selection.UpdateSelectionRotationAngle(new SKPoint(50f, 50f));
+
+        selection.SelectionRotationAngle.Should().BeApproximately(0.0, 1e-10);
+    }
+
+    [Fact]
+    public void UpdateSelectionRotationAngle_UsesSelectionCenterAsOrigin()
+    {
+        // Shift both center and reference by the same amount — angle must be identical
+        var selection = new Selection
+        {
+            SelectionCenter = new SKPoint(100f, 100f)
+        };
+
+        selection.UpdateSelectionRotationAngle(new SKPoint(101f, 100f));
+
+        selection.SelectionRotationAngle.Should().BeApproximately(0.0, 1e-10);
+    }
+
+    // RefreshScalePivot
+    [Fact]
+    public void RefreshScalePivot_TopLeftHandle_PivotIsBottomRight()
+    {
+        var selection = new Selection
+        {
+            SelectionBounds = SKRect.Create(0f, 0f, 100f, 80f),
+            ActiveScaleHandle = "ScaleHandleTl"
+        };
+
+        selection.RefreshScalePivot();
+
+        selection.ScalePivot.Should().Be(new SKPoint(100f, 80f));
+    }
+
+    [Fact]
+    public void RefreshScalePivot_TopRightHandle_PivotIsBottomLeft()
+    {
+        var selection = new Selection
+        {
+            SelectionBounds = SKRect.Create(0f, 0f, 100f, 80f),
+            ActiveScaleHandle = "ScaleHandleTr"
+        };
+
+        selection.RefreshScalePivot();
+
+        selection.ScalePivot.Should().Be(new SKPoint(0f, 80f));
+    }
+
+    [Fact]
+    public void RefreshScalePivot_BottomLeftHandle_PivotIsTopRight()
+    {
+        var selection = new Selection
+        {
+            SelectionBounds = SKRect.Create(0f, 0f, 100f, 80f),
+            ActiveScaleHandle = "ScaleHandleBl"
+        };
+
+        selection.RefreshScalePivot();
+
+        selection.ScalePivot.Should().Be(new SKPoint(100f, 0f));
+    }
+
+    [Fact]
+    public void RefreshScalePivot_BottomRightHandle_PivotIsTopLeft()
+    {
+        var selection = new Selection
+        {
+            SelectionBounds = SKRect.Create(0f, 0f, 100f, 80f),
+            ActiveScaleHandle = "ScaleHandleBr"
+        };
+
+        selection.RefreshScalePivot();
+
+        selection.ScalePivot.Should().Be(new SKPoint(0f, 0f));
+    }
+
+    [Fact]
+    public void RefreshScalePivot_UnknownHandle_PivotIsNotChanged()
+    {
+        var originalPivot = new SKPoint(99f, 99f);
+        var selection = new Selection
+        {
+            SelectionBounds = SKRect.Create(0f, 0f, 100f, 80f),
+            ActiveScaleHandle = "UnknownHandle",
+            ScalePivot = originalPivot
+        };
+
+        selection.RefreshScalePivot();
+
+        selection.ScalePivot.Should().Be(originalPivot);
+    }
+
+    [Fact]
+    public void RefreshScalePivot_NullHandle_PivotIsNotChanged()
+    {
+        var originalPivot = new SKPoint(99f, 99f);
+        var selection = new Selection
+        {
+            SelectionBounds = SKRect.Create(0f, 0f, 100f, 80f),
+            ActiveScaleHandle = null,
+            ScalePivot = originalPivot
+        };
+
+        selection.RefreshScalePivot();
+
+        selection.ScalePivot.Should().Be(originalPivot);
+    }
+}

--- a/Scribble.Tests/TestAppBuilder.cs
+++ b/Scribble.Tests/TestAppBuilder.cs
@@ -1,0 +1,13 @@
+using Avalonia;
+using Avalonia.Headless;
+
+[assembly: AvaloniaTestApplication(typeof(Scribble.Tests.TestAppBuilder))]
+
+namespace Scribble.Tests;
+
+public class TestAppBuilder
+{
+    public static AppBuilder BuildAvaloniaApp() =>
+        AppBuilder.Configure<HeadlessApp>()
+            .UseHeadless(new AvaloniaHeadlessPlatformOptions());
+}

--- a/Scribble.Tests/Utils/FreehandPathBuilderTests.cs
+++ b/Scribble.Tests/Utils/FreehandPathBuilderTests.cs
@@ -1,0 +1,145 @@
+using FluentAssertions;
+using Scribble.Shared.Lib.CanvasElements.Strokes;
+using Scribble.Utils;
+using SkiaSharp;
+
+namespace Scribble.Tests.Utils;
+
+public class FreehandPathBuilderTests
+{
+    // helpers
+    private static StrokePoint Pt(float x, float y) =>
+        new StrokePoint { Point = new SKPoint(x, y) };
+
+    /// <summary>Iterates the path and returns every (verb, points) pair.</summary>
+    private static List<(SKPathVerb Verb, SKPoint[] Points)> GetVerbs(SKPath path)
+    {
+        var result = new List<(SKPathVerb, SKPoint[])>();
+        using var iter = path.CreateIterator(false);
+        var points = new SKPoint[4];
+        SKPathVerb verb;
+        while ((verb = iter.Next(points)) != SKPathVerb.Done)
+        {
+            result.Add((verb, (SKPoint[])points.Clone()));
+        }
+
+        return result;
+    }
+
+    // 0 points
+    [Fact]
+    public void Build_EmptyPoints_ReturnsEmptyPath()
+    {
+        var path = FreehandPathBuilder.Build([]);
+
+        path.IsEmpty.Should().BeTrue();
+    }
+
+    // 1 point
+    [Fact]
+    public void Build_SinglePoint_ReturnsPathWithSingleRecordedPoint()
+    {
+        var path = FreehandPathBuilder.Build([Pt(2f, 2f)]);
+
+        path.PointCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void Build_SinglePoint_MoveToIsAtCorrectPosition()
+    {
+        var point = new SKPoint(2f, 2f);
+        var path = FreehandPathBuilder.Build([new StrokePoint { Point = point }]);
+
+        path.GetPoint(0).Should().Be(point);
+    }
+
+    // 2 points
+    [Fact]
+    public void Build_TwoPoints_ProducesMoveThenLine()
+    {
+        var path = FreehandPathBuilder.Build([Pt(0f, 0f), Pt(10f, 10f)]);
+
+        var verbs = GetVerbs(path);
+        verbs.Should().HaveCount(2);
+        verbs[0].Verb.Should().Be(SKPathVerb.Move);
+        verbs[1].Verb.Should().Be(SKPathVerb.Line);
+    }
+
+    [Fact]
+    public void Build_TwoPoints_LineStartsAtFirstPoint()
+    {
+        var path = FreehandPathBuilder.Build([Pt(0f, 0f), Pt(10f, 10f)]);
+
+        path.GetPoint(0).Should().Be(new SKPoint(0f, 0f));
+    }
+
+    [Fact]
+    public void Build_TwoPoints_LineEndsAtSecondPoint()
+    {
+        var path = FreehandPathBuilder.Build([Pt(0f, 0f), Pt(10f, 10f)]);
+
+        var verbs = GetVerbs(path);
+        var lineVerb = verbs.Single(v => v.Verb == SKPathVerb.Line);
+        lineVerb.Points[1].Should().Be(new SKPoint(10f, 10f));
+    }
+
+    // 3+ points
+    [Fact]
+    public void Build_ThreePoints_ProducesMoveThenQuadThenLine()
+    {
+        var path = FreehandPathBuilder.Build([Pt(0f, 0f), Pt(10f, 0f), Pt(20f, 0f)]);
+
+        var verbs = GetVerbs(path);
+        verbs.Select(v => v.Verb).Should().Equal(
+            SKPathVerb.Move,
+            SKPathVerb.Quad,
+            SKPathVerb.Line);
+    }
+
+    [Fact]
+    public void Build_ThreePoints_QuadControlPointIsSecondInputPoint()
+    {
+        // For 3 points p0, p1, p2: QuadTo(p1, midpoint(p1,p2))
+        var path = FreehandPathBuilder.Build([Pt(0f, 0f), Pt(10f, 0f), Pt(20f, 0f)]);
+
+        var verbs = GetVerbs(path);
+        var quad = verbs.Single(v => v.Verb == SKPathVerb.Quad);
+        // pts[0] = start (implicit), pts[1] = control, pts[2] = end
+        quad.Points[1].Should().Be(new SKPoint(10f, 0f));
+    }
+
+    [Fact]
+    public void Build_ThreePoints_QuadEndPointIsMidpointOfSecondAndThirdInputPoints()
+    {
+        // midpoint of (10,0) and (20,0) = (15,0)
+        var path = FreehandPathBuilder.Build([Pt(0f, 0f), Pt(10f, 0f), Pt(20f, 0f)]);
+
+        var verbs = GetVerbs(path);
+        var quad = verbs.Single(v => v.Verb == SKPathVerb.Quad);
+        quad.Points[2].Should().Be(new SKPoint(15f, 0f));
+    }
+
+    [Fact]
+    public void Build_ThreePoints_LineEndsAtLastInputPoint()
+    {
+        var path = FreehandPathBuilder.Build([Pt(0f, 0f), Pt(10f, 0f), Pt(20f, 0f)]);
+
+        var verbs = GetVerbs(path);
+        var line = verbs.Single(v => v.Verb == SKPathVerb.Line);
+        line.Points[1].Should().Be(new SKPoint(20f, 0f));
+    }
+
+    [Fact]
+    public void Build_FourPoints_ProducesMoveTwoQuadsThenLine()
+    {
+        var path = FreehandPathBuilder.Build(
+            [Pt(0f, 0f), Pt(10f, 0f), Pt(20f, 0f), Pt(30f, 0f)]);
+
+        var verbs = GetVerbs(path);
+        verbs.Select(v => v.Verb).Should().Equal(
+            SKPathVerb.Move,
+            SKPathVerb.Quad,
+            SKPathVerb.Quad,
+            SKPathVerb.Line);
+    }
+}

--- a/Scribble.Tests/Utils/UtilitiesTests.cs
+++ b/Scribble.Tests/Utils/UtilitiesTests.cs
@@ -1,0 +1,43 @@
+using Avalonia.Media;
+using FluentAssertions;
+using Scribble.Utils;
+using SkiaSharp;
+
+namespace Scribble.Tests.Utils;
+
+public class UtilitiesTests
+{
+    [Fact]
+    public void ToSkColor_OpaqueColor_ReturnsEquivalentSkColor()
+    {
+        var brown = Colors.Brown;
+
+        var actual = Utilities.ToSkColor(brown);
+
+        actual.Should().Be(SKColors.Brown);
+    }
+
+    [Fact]
+    public void ToSkColor_SlightlyTransparentColor_ReturnsEquivalentSkColor()
+    {
+        var brown = Colors.Brown;
+        var slightlyTransparentBrown = Color.FromArgb(100, brown.R, brown.G, brown.B);
+
+        var actual = Utilities.ToSkColor(slightlyTransparentBrown);
+
+        var expected = SKColors.Brown.WithAlpha(100);
+        actual.Should().Be(expected);
+    }
+
+    [Fact]
+    public void ToSkColor_FullyTransparentColor_ReturnsTransparentSkColor()
+    {
+        var brown = Colors.Brown;
+        var transparentBrown = Color.FromArgb(0, brown.R, brown.G, brown.B);
+
+        var actual = Utilities.ToSkColor(transparentBrown);
+
+        var expected = SKColors.Brown.WithAlpha(0);
+        actual.Should().Be(expected);
+    }
+}

--- a/Scribble.Tests/Utils/UtilitiesTests.cs
+++ b/Scribble.Tests/Utils/UtilitiesTests.cs
@@ -1,3 +1,4 @@
+using Avalonia;
 using Avalonia.Media;
 using FluentAssertions;
 using Scribble.Utils;
@@ -7,6 +8,7 @@ namespace Scribble.Tests.Utils;
 
 public class UtilitiesTests
 {
+    // ToSkColor
     [Fact]
     public void ToSkColor_OpaqueColor_ReturnsEquivalentSkColor()
     {
@@ -39,5 +41,239 @@ public class UtilitiesTests
 
         var expected = SKColors.Brown.WithAlpha(0);
         actual.Should().Be(expected);
+    }
+
+    // FromSkColor
+    [Fact]
+    public void FromSkColor_OpaqueSkColor_ReturnsEquivalentColor()
+    {
+        var skBrown = SKColors.Brown;
+
+        var actual = Utilities.FromSkColor(skBrown);
+
+        actual.Should().Be(Colors.Brown);
+    }
+
+    [Fact]
+    public void FromSkColor_SlightlyTransparentSkColor_ReturnsEquivalentColor()
+    {
+        var skBrown = SKColors.Brown.WithAlpha(100);
+
+        var actual = Utilities.FromSkColor(skBrown);
+
+        var brown = Colors.Brown;
+        var expected = Color.FromArgb(100, brown.R, brown.G, brown.B);
+        actual.Should().Be(expected);
+    }
+
+    [Fact]
+    public void FromSkColor_FullyTransparentSkColor_ReturnsEquivalentColor()
+    {
+        var skBrown = SKColors.Brown.WithAlpha(0);
+
+        var actual = Utilities.FromSkColor(skBrown);
+
+        var brown = Colors.Brown;
+        var expected = Color.FromArgb(0, brown.R, brown.G, brown.B);
+        actual.Should().Be(expected);
+    }
+
+    // GetSize
+    [Fact]
+    public void GetSize_TwoDistinctPoints_ReturnsAbsoluteDimensions()
+    {
+        var start = new SKPoint(10f, 20f);
+        var end = new SKPoint(40f, 60f);
+
+        var actual = Utilities.GetSize(start, end);
+
+        actual.Should().Be(new SKSize(30f, 40f));
+    }
+
+    [Fact]
+    public void GetSize_EndPointIsTopLeft_ReturnsPositiveDimensions()
+    {
+        // end is "before" start, width/height should still be positive
+        var start = new SKPoint(40f, 60f);
+        var end = new SKPoint(10f, 20f);
+
+        var actual = Utilities.GetSize(start, end);
+
+        actual.Should().Be(new SKSize(30f, 40f));
+    }
+
+    [Fact]
+    public void GetSize_SamePoint_ReturnsZeroSize()
+    {
+        var point = new SKPoint(15f, 25f);
+
+        var actual = Utilities.GetSize(point, point);
+
+        actual.Should().Be(new SKSize(0f, 0f));
+    }
+
+    // ToSkPoint
+    [Fact]
+    public void ToSkPoint_PositiveCoordinates_ReturnsEquivalentSkPoint()
+    {
+        var point = new Point(123.5, 456.75);
+
+        var actual = Utilities.ToSkPoint(point);
+
+        actual.Should().Be(new SKPoint(123.5f, 456.75f));
+    }
+
+    [Fact]
+    public void ToSkPoint_Origin_ReturnsZeroSkPoint()
+    {
+        var actual = Utilities.ToSkPoint(new Point(0, 0));
+
+        actual.Should().Be(new SKPoint(0f, 0f));
+    }
+
+    // FromSkPoint
+    [Fact]
+    public void FromSkPoint_PositiveCoordinates_ReturnsEquivalentPoint()
+    {
+        var skPoint = new SKPoint(123.5f, 456.75f);
+
+        var actual = Utilities.FromSkPoint(skPoint);
+
+        actual.Should().Be(new Point(123.5f, 456.75f));
+    }
+
+    [Fact]
+    public void FromSkPoint_Origin_ReturnsZeroPoint()
+    {
+        var actual = Utilities.FromSkPoint(new SKPoint(0f, 0f));
+
+        actual.Should().Be(new Point(0, 0));
+    }
+
+    // AreSamePosition
+    [Fact]
+    public void AreSamePosition_IdenticalPoints_ReturnsTrue()
+    {
+        var point = new SKPoint(50f, 50f);
+
+        var actual = Utilities.AreSamePosition(point, point);
+
+        actual.Should().BeTrue();
+    }
+
+    [Fact]
+    public void AreSamePosition_PointsWithinDefaultEpsilon_ReturnsTrue()
+    {
+        var a = new SKPoint(50f, 50f);
+        var b = new SKPoint(50.4f, 50.4f); // difference < 0.5 on both axes
+
+        var actual = Utilities.AreSamePosition(a, b);
+
+        actual.Should().BeTrue();
+    }
+
+    [Fact]
+    public void AreSamePosition_PointsOutsideDefaultEpsilon_ReturnsFalse()
+    {
+        var a = new SKPoint(50f, 50f);
+        var b = new SKPoint(50.6f, 50f); // X difference >= 0.5
+
+        var actual = Utilities.AreSamePosition(a, b);
+
+        actual.Should().BeFalse();
+    }
+
+    [Fact]
+    public void AreSamePosition_PointsWithinCustomEpsilon_ReturnsTrue()
+    {
+        var a = new SKPoint(10f, 10f);
+        var b = new SKPoint(11.9f, 11.9f);
+
+        var actual = Utilities.AreSamePosition(a, b, epsilon: 2.0);
+
+        actual.Should().BeTrue();
+    }
+
+    [Fact]
+    public void AreSamePosition_PointsOutsideCustomEpsilon_ReturnsFalse()
+    {
+        var a = new SKPoint(10f, 10f);
+        var b = new SKPoint(12.1f, 10f);
+
+        var actual = Utilities.AreSamePosition(a, b, epsilon: 2.0);
+
+        actual.Should().BeFalse();
+    }
+
+    // IsPointNearLine
+    [Fact]
+    public void IsPointNearLine_PointOnSegment_ReturnsTrue()
+    {
+        var start = new SKPoint(0f, 0f);
+        var end = new SKPoint(10f, 0f);
+        var point = new SKPoint(5f, 0f); // exactly on the midpoint
+
+        var actual = Utilities.IsPointNearLine(point, [start, end], tolerance: 1f);
+
+        actual.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsPointNearLine_PointWithinTolerance_ReturnsTrue()
+    {
+        var start = new SKPoint(0f, 0f);
+        var end = new SKPoint(10f, 0f);
+        var point = new SKPoint(5f, 0.8f); // 0.8 units above midpoint, tolerance is 1
+
+        var actual = Utilities.IsPointNearLine(point, [start, end], tolerance: 1f);
+
+        actual.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsPointNearLine_PointOutsideTolerance_ReturnsFalse()
+    {
+        var start = new SKPoint(0f, 0f);
+        var end = new SKPoint(10f, 0f);
+        var point = new SKPoint(5f, 5f); // 5 units above, far outside tolerance
+
+        var actual = Utilities.IsPointNearLine(point, [start, end], tolerance: 1f);
+
+        actual.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsPointNearLine_PointBeyondEndpoint_UsesClosestEndpoint()
+    {
+        // Projection of point falls outside the segment; nearest point is the endpoint
+        var start = new SKPoint(0f, 0f);
+        var end = new SKPoint(10f, 0f);
+        var point = new SKPoint(12f, 0f); // 2 units past the end
+
+        var actual = Utilities.IsPointNearLine(point, [start, end], tolerance: 3f);
+
+        actual.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsPointNearLine_ZeroLengthLine_TreatsAsPoint()
+    {
+        var start = new SKPoint(5f, 5f);
+        var point = new SKPoint(5f, 5.5f); // 0.5 units from the start point
+
+        var actual = Utilities.IsPointNearLine(point, [start, start], tolerance: 1f);
+
+        actual.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsPointNearLine_ZeroLengthLine_PointTooFar_ReturnsFalse()
+    {
+        var start = new SKPoint(5f, 5f);
+        var point = new SKPoint(5f, 10f); // 5 units away
+
+        var actual = Utilities.IsPointNearLine(point, [start, start], tolerance: 1f);
+
+        actual.Should().BeFalse();
     }
 }

--- a/Scribble.Tests/UtilsTests/FreehandPathBuilderTests.cs
+++ b/Scribble.Tests/UtilsTests/FreehandPathBuilderTests.cs
@@ -3,7 +3,7 @@ using Scribble.Shared.Lib.CanvasElements.Strokes;
 using Scribble.Utils;
 using SkiaSharp;
 
-namespace Scribble.Tests.Utils;
+namespace Scribble.Tests.UtilsTests;
 
 public class FreehandPathBuilderTests
 {

--- a/Scribble.Tests/UtilsTests/UtilitiesTests.cs
+++ b/Scribble.Tests/UtilsTests/UtilitiesTests.cs
@@ -4,7 +4,7 @@ using FluentAssertions;
 using Scribble.Utils;
 using SkiaSharp;
 
-namespace Scribble.Tests.Utils;
+namespace Scribble.Tests.UtilsTests;
 
 public class UtilitiesTests
 {

--- a/Scribble.slnx
+++ b/Scribble.slnx
@@ -10,5 +10,6 @@
 <!--  <Project Path="Scribble.iOS/Scribble.iOS.csproj" />-->
   <Project Path="Scribble.Server/Scribble.Server.csproj" />
   <Project Path="Scribble.Shared/Scribble.Shared.csproj" />
+  <Project Path="Scribble.Tests/Scribble.Tests.csproj" />
   <Project Path="Scribble/Scribble.csproj" />
 </Solution>

--- a/Scribble/Converters/BoolToBrushConverter.cs
+++ b/Scribble/Converters/BoolToBrushConverter.cs
@@ -11,20 +11,20 @@ namespace Scribble.Converters;
 /// </summary>
 public class BoolToBrushConverter : IValueConverter
 {
-    private static readonly IBrush OwnMessageBrush = new SolidColorBrush(Color.Parse("#00BFFF"));
-    private static readonly IBrush OtherMessageBrush = new SolidColorBrush(Color.Parse("#7CFC00"));
-    private static readonly IBrush SentMessageBrush = new SolidColorBrush(Color.Parse("#FFFFFF"));
-    private static readonly IBrush PendingMessageBrush = new SolidColorBrush(Color.Parse("#808080"));
+    public static readonly SolidColorBrush OwnMessageBrush = new(Color.Parse("#00BFFF"));
+    public static readonly SolidColorBrush OtherMessageBrush = new(Color.Parse("#7CFC00"));
+    public static readonly SolidColorBrush SentMessageBrush = new(Color.Parse("#FFFFFF"));
+    public static readonly SolidColorBrush PendingMessageBrush = new(Color.Parse("#808080"));
 
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         if (parameter is string status && value is bool statusValue)
         {
-            switch (status)
+            switch (status.ToLowerInvariant())
             {
-                case "ownershipStatus":
+                case "ownershipstatus":
                     return statusValue ? OwnMessageBrush : OtherMessageBrush;
-                case "sentStatus":
+                case "sentstatus":
                     return statusValue ? SentMessageBrush : PendingMessageBrush;
             }
         }

--- a/Scribble/Extensions/ServiceCollectionExtensions.cs
+++ b/Scribble/Extensions/ServiceCollectionExtensions.cs
@@ -38,7 +38,7 @@ public static class ServiceCollectionExtensions
         collection.AddTransient<MainViewModel>();
 
         collection.AddSingleton<IFileService, AvaloniaFileService>();
-
         collection.AddSingleton<IDialogService, AvaloniaDialogService>();
+        collection.AddSingleton<AutoSaveService>();
     }
 }

--- a/Scribble/Extensions/ServiceCollectionExtensions.cs
+++ b/Scribble/Extensions/ServiceCollectionExtensions.cs
@@ -1,8 +1,10 @@
 using System;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Scribble.Services;
+using Scribble.Services.AutoSaveService;
+using Scribble.Services.CanvasStateService;
 using Scribble.Services.DialogService;
+using Scribble.Services.DocumentService;
 using Scribble.Services.FileService;
 using Scribble.Services.MultiUserDrawing;
 using Scribble.ViewModels;
@@ -27,9 +29,10 @@ public static class ServiceCollectionExtensions
         collection.AddSingleton<IConfiguration>(config);
 
         var serverUrl = config["ServerUrl"] ?? throw new Exception("ServerUrl is missing");
-        collection.AddSingleton(new MultiUserDrawingService(serverUrl));
-        collection.AddSingleton<CanvasStateService>();
-        collection.AddSingleton<DocumentService>();
+        collection.AddSingleton<IMultiUserDrawingService, MultiUserDrawingService>(_ =>
+            new MultiUserDrawingService(serverUrl));
+        collection.AddSingleton<ICanvasStateService, CanvasStateService>();
+        collection.AddSingleton<IDocumentService, DocumentService>();
 
         collection.AddTransient<CanvasExportViewModel>();
         collection.AddTransient<UiStateViewModel>();

--- a/Scribble/Scribble.csproj
+++ b/Scribble/Scribble.csproj
@@ -43,4 +43,8 @@
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
     </ItemGroup>
+
+    <ItemGroup>
+        <InternalsVisibleTo Include="Scribble.Tests" />
+    </ItemGroup>
 </Project>

--- a/Scribble/Services/AutoSaveService.cs
+++ b/Scribble/Services/AutoSaveService.cs
@@ -1,0 +1,184 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Scribble.Services.MultiUserDrawing;
+
+namespace Scribble.Services;
+
+/// <summary>
+/// Handles autosaving the canvas state and loading it on app startup
+/// </summary>
+public class AutoSaveService : IDisposable
+{
+    private readonly CanvasStateService _canvasStateService;
+    private readonly DocumentService _documentService;
+    private readonly MultiUserDrawingService _multiUserDrawingService;
+
+    private readonly string _appDataPath;
+    private readonly SemaphoreSlim _saveLock = new(1, 1);
+    private CancellationTokenSource? _cts;
+    private CancellationTokenSource? _maxDelayCts;
+    private bool _hasUnsavedChanges;
+
+    public AutoSaveService(CanvasStateService canvasStateService, DocumentService documentService,
+        MultiUserDrawingService multiUserDrawingService)
+    {
+        _canvasStateService = canvasStateService;
+        _documentService = documentService;
+        _multiUserDrawingService = multiUserDrawingService;
+
+        _canvasStateService.CanvasInvalidated += OnCanvasInvalidated;
+        _multiUserDrawingService.RoomChanged += room =>
+        {
+            if (room != null)
+            {
+                PauseAutoSave();
+            }
+        };
+
+        var baseDirectory = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        _appDataPath = Path.Combine(baseDirectory, "Scribble");
+        // Create the app data folder if it doesn't exist
+        Directory.CreateDirectory(_appDataPath);
+
+        LoadAutoSavedState();
+    }
+
+    private async void OnCanvasInvalidated()
+    {
+        try
+        {
+            if (_multiUserDrawingService.Room != null) return;
+            if (!_hasUnsavedChanges)
+            {
+                _hasUnsavedChanges = true;
+                _ = StartMaxDelayTimer();
+            }
+
+            await AutoSaveAsync();
+        }
+        catch (TaskCanceledException)
+        {
+            // Expected behaviour
+        }
+    }
+
+    /// <summary>
+    /// Starts a timer that will wait a max of 10 seconds before saving the canvas state
+    /// </summary>
+    private async Task StartMaxDelayTimer()
+    {
+        try
+        {
+            _maxDelayCts?.Cancel();
+            _maxDelayCts?.Dispose();
+            _maxDelayCts = new CancellationTokenSource();
+            var token = _maxDelayCts.Token;
+            await Task.Delay(TimeSpan.FromSeconds(10), token);
+            await WriteToDiskAsync();
+        }
+        catch (TaskCanceledException)
+        {
+            // Expected behaviour
+        }
+    }
+
+    /// <summary>
+    /// Loads the autosaved state from the autosaved state file
+    /// </summary>
+    private void LoadAutoSavedState()
+    {
+        var autosavedStateFilePath = Path.Combine(_appDataPath, "autosave.scribble");
+        if (File.Exists(autosavedStateFilePath))
+        {
+            _ = _documentService.LoadAsync(File.OpenRead(autosavedStateFilePath));
+        }
+    }
+
+    /// <summary>
+    /// Saves the canvas state to the autosaved state file
+    /// </summary>
+    private async Task AutoSaveAsync()
+    {
+        _cts?.Cancel();
+        _cts?.Dispose();
+
+        _cts = new CancellationTokenSource();
+        var token = _cts.Token;
+        try
+        {
+            // wait for the debounce period
+            await Task.Delay(TimeSpan.FromSeconds(2), token);
+
+            await WriteToDiskAsync();
+            _maxDelayCts?.Cancel();
+            _maxDelayCts?.Dispose();
+            _maxDelayCts = null;
+        }
+        catch (TaskCanceledException)
+        {
+            // Ignore, this is expected behaviour
+        }
+    }
+
+    /// <summary>
+    /// Writes the canvas state to the autosaved state file
+    /// </summary>
+    private async Task WriteToDiskAsync()
+    {
+        // ensures only one write operation runs at a time
+        await _saveLock.WaitAsync();
+        try
+        {
+            // Write the data to a temporary file and move it to the autosaved state file
+            if (_hasUnsavedChanges)
+            {
+                var autosavedStateFilePath = Path.Combine(_appDataPath, "autosave.scribble");
+                var tempPath = Path.Combine(_appDataPath, "autosave.scribble.tmp");
+                await using var fileStream = File.OpenWrite(tempPath);
+                await _documentService.SaveAsync(fileStream);
+                File.Move(tempPath, autosavedStateFilePath, overwrite: true);
+                _hasUnsavedChanges = false;
+            }
+        }
+        finally
+        {
+            _saveLock.Release();
+        }
+    }
+
+    private void PauseAutoSave()
+    {
+        _cts?.Cancel();
+        _cts?.Dispose();
+        _cts = null;
+        _maxDelayCts?.Cancel();
+        _maxDelayCts?.Dispose();
+        _maxDelayCts = null;
+        _hasUnsavedChanges = false;
+    }
+
+    /// <summary>
+    /// Deletes the autosaved state file
+    /// </summary>
+    public void DeleteAutoSavedState()
+    {
+        var autosavedStateFilePath = Path.Combine(_appDataPath, "autosave.scribble");
+        if (File.Exists(autosavedStateFilePath))
+        {
+            File.Delete(autosavedStateFilePath);
+        }
+    }
+
+    public void Dispose()
+    {
+        _cts?.Cancel();
+        _cts?.Dispose();
+        _cts = null;
+        _maxDelayCts?.Cancel();
+        _maxDelayCts?.Dispose();
+        _maxDelayCts = null;
+        _saveLock.Dispose();
+    }
+}

--- a/Scribble/Services/AutoSaveService/AutoSaveService.cs
+++ b/Scribble/Services/AutoSaveService/AutoSaveService.cs
@@ -18,6 +18,8 @@ public class AutoSaveService : IDisposable
     private readonly IMultiUserDrawingService _multiUserDrawingService;
 
     private readonly string _appDataPath;
+    private readonly TimeSpan _debounceDelay;
+    private readonly TimeSpan _maxDelay;
     private readonly SemaphoreSlim _saveLock = new(1, 1);
     private CancellationTokenSource? _cts;
     private CancellationTokenSource? _maxDelayCts;
@@ -25,10 +27,23 @@ public class AutoSaveService : IDisposable
 
     public AutoSaveService(ICanvasStateService canvasStateService, IDocumentService documentService,
         IMultiUserDrawingService multiUserDrawingService)
+        : this(canvasStateService, documentService, multiUserDrawingService,
+            customBaseDirectory: Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData))
+    {
+    }
+
+    /// <summary>
+    /// Constructor for testing purposes
+    /// </summary>
+    internal AutoSaveService(ICanvasStateService canvasStateService, IDocumentService documentService,
+        IMultiUserDrawingService multiUserDrawingService, string customBaseDirectory,
+        TimeSpan? debounceDelay = null, TimeSpan? maxDelay = null)
     {
         _canvasStateService = canvasStateService;
         _documentService = documentService;
         _multiUserDrawingService = multiUserDrawingService;
+        _debounceDelay = debounceDelay ?? TimeSpan.FromSeconds(2);
+        _maxDelay = maxDelay ?? TimeSpan.FromSeconds(10);
 
         _canvasStateService.CanvasInvalidated += OnCanvasInvalidated;
         _multiUserDrawingService.RoomChanged += room =>
@@ -39,9 +54,7 @@ public class AutoSaveService : IDisposable
             }
         };
 
-        var baseDirectory = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        _appDataPath = Path.Combine(baseDirectory, "Scribble");
-        // Create the app data folder if it doesn't exist
+        _appDataPath = Path.Combine(customBaseDirectory, "Scribble");
         Directory.CreateDirectory(_appDataPath);
 
         LoadAutoSavedState();
@@ -77,7 +90,7 @@ public class AutoSaveService : IDisposable
             _maxDelayCts?.Dispose();
             _maxDelayCts = new CancellationTokenSource();
             var token = _maxDelayCts.Token;
-            await Task.Delay(TimeSpan.FromSeconds(10), token);
+            await Task.Delay(_maxDelay, token);
             await WriteToDiskAsync();
         }
         catch (TaskCanceledException)
@@ -111,7 +124,7 @@ public class AutoSaveService : IDisposable
         try
         {
             // wait for the debounce period
-            await Task.Delay(TimeSpan.FromSeconds(2), token);
+            await Task.Delay(_debounceDelay, token);
 
             await WriteToDiskAsync();
             _maxDelayCts?.Cancel();

--- a/Scribble/Services/AutoSaveService/AutoSaveService.cs
+++ b/Scribble/Services/AutoSaveService/AutoSaveService.cs
@@ -2,18 +2,20 @@ using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Scribble.Services.CanvasStateService;
+using Scribble.Services.DocumentService;
 using Scribble.Services.MultiUserDrawing;
 
-namespace Scribble.Services;
+namespace Scribble.Services.AutoSaveService;
 
 /// <summary>
 /// Handles autosaving the canvas state and loading it on app startup
 /// </summary>
 public class AutoSaveService : IDisposable
 {
-    private readonly CanvasStateService _canvasStateService;
-    private readonly DocumentService _documentService;
-    private readonly MultiUserDrawingService _multiUserDrawingService;
+    private readonly ICanvasStateService _canvasStateService;
+    private readonly IDocumentService _documentService;
+    private readonly IMultiUserDrawingService _multiUserDrawingService;
 
     private readonly string _appDataPath;
     private readonly SemaphoreSlim _saveLock = new(1, 1);
@@ -21,8 +23,8 @@ public class AutoSaveService : IDisposable
     private CancellationTokenSource? _maxDelayCts;
     private bool _hasUnsavedChanges;
 
-    public AutoSaveService(CanvasStateService canvasStateService, DocumentService documentService,
-        MultiUserDrawingService multiUserDrawingService)
+    public AutoSaveService(ICanvasStateService canvasStateService, IDocumentService documentService,
+        IMultiUserDrawingService multiUserDrawingService)
     {
         _canvasStateService = canvasStateService;
         _documentService = documentService;

--- a/Scribble/Services/CanvasStateService/CanvasStateService.cs
+++ b/Scribble/Services/CanvasStateService/CanvasStateService.cs
@@ -11,9 +11,9 @@ using Scribble.Tools.PointerTools.ArrowTool;
 using Scribble.Utils;
 using SkiaSharp;
 
-namespace Scribble.Services;
+namespace Scribble.Services.CanvasStateService;
 
-public class CanvasStateService
+public class CanvasStateService : ICanvasStateService
 {
     // State
     public IReadOnlyList<CanvasElement> CanvasElements { get; private set; } = [];
@@ -39,7 +39,7 @@ public class CanvasStateService
     public bool CanUndo => _undoStack.Count > 0;
     public bool CanRedo => _redoStack.Count > 0;
 
-    private readonly MultiUserDrawingService _multiUserDrawingService;
+    private readonly IMultiUserDrawingService _multiUserDrawingService;
 
     public event Action? CanvasInvalidated;
     public event Action? SelectionInvalidated;
@@ -53,7 +53,7 @@ public class CanvasStateService
         BackgroundColorChanged?.Invoke();
     }
 
-    public CanvasStateService(MultiUserDrawingService multiUserDrawingService)
+    public CanvasStateService(IMultiUserDrawingService multiUserDrawingService)
     {
         _multiUserDrawingService = multiUserDrawingService;
 

--- a/Scribble/Services/CanvasStateService/ICanvasStateService.cs
+++ b/Scribble/Services/CanvasStateService/ICanvasStateService.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using Scribble.Shared.Lib;
+using Scribble.Shared.Lib.CanvasElements;
+using SkiaSharp;
+
+namespace Scribble.Services.CanvasStateService;
+
+public interface ICanvasStateService
+{
+    // State
+    IReadOnlyList<CanvasElement> CanvasElements { get; }
+    Queue<Event> CanvasEvents { get; }
+    Guid? ActiveSelectionBoundId { get; }
+    List<Guid> SelectedElementIds { get; }
+    SKColor BackgroundColor { get; }
+    bool HasEvents { get; }
+    bool CanUndo { get; }
+    bool CanRedo { get; }
+
+    // Events
+    event Action? CanvasInvalidated;
+    event Action? SelectionInvalidated;
+    event Action? UndoRedoStateChanged;
+    event Action? BackgroundColorChanged;
+
+    // Methods
+    void SetBackgroundColor(SKColor color);
+    void Undo();
+    void Redo();
+    void ClearSelection();
+    List<CanvasElement> GetSelectedElements();
+    void LoadCanvas(List<CanvasElement> elements);
+    void ApplyEvent(Event @event, bool isLocalEvent = true);
+    bool IsLocalSelection(Guid boundId);
+}

--- a/Scribble/Services/DocumentService.cs
+++ b/Scribble/Services/DocumentService.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
+using Avalonia.Threading;
 using Scribble.Dtos;
 using Scribble.Shared.Lib.CanvasElements;
 using Scribble.Shared.Lib.CanvasElements.Strokes;
@@ -23,69 +25,77 @@ public class DocumentService
 
     public async Task SaveAsync(Stream stream)
     {
-        var canvasElements = _canvasStateService.CanvasElements;
-        var backgroundColor = _canvasStateService.BackgroundColor;
-
-        await using var streamWriter = new StreamWriter(stream);
-
-        var serializerOptions = new JsonSerializerOptions
+        List<CanvasElement> canvasElements = [];
+        SKColor backgroundColor = default;
+        Dispatcher.UIThread.Invoke(() =>
         {
-            WriteIndented = true,
-            Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
-        };
-        var jsonCanvasStrokes = new JsonArray();
-        var jsonCanvasImages = new JsonArray();
-        Dictionary<string, Guid> imageBase64EncodedStrings = [];
-        foreach (var element in canvasElements)
+            canvasElements = _canvasStateService.CanvasElements.ToList();
+            backgroundColor = _canvasStateService.BackgroundColor;
+        });
+
+        await Task.Run(async () =>
         {
-            if (element is Stroke stroke)
+            await using var streamWriter = new StreamWriter(stream);
+
+            var serializerOptions = new JsonSerializerOptions
             {
-                jsonCanvasStrokes.Add(JsonSerializer.SerializeToNode(stroke, serializerOptions));
-            }
-            else if (element is CanvasImage canvasImage)
+                WriteIndented = true,
+                Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
+            };
+            var jsonCanvasStrokes = new JsonArray();
+            var jsonCanvasImages = new JsonArray();
+            Dictionary<string, Guid> imageBase64EncodedStrings = [];
+            foreach (var element in canvasElements)
             {
-                Guid fileId;
-                if (imageBase64EncodedStrings.ContainsKey(canvasImage.ImageBase64String))
+                if (element is Stroke stroke)
                 {
-                    fileId = imageBase64EncodedStrings[canvasImage.ImageBase64String];
+                    jsonCanvasStrokes.Add(JsonSerializer.SerializeToNode(stroke, serializerOptions));
                 }
-                else
+                else if (element is CanvasImage canvasImage)
                 {
-                    fileId = Guid.NewGuid();
-                    imageBase64EncodedStrings[canvasImage.ImageBase64String] = fileId;
+                    Guid fileId;
+                    if (imageBase64EncodedStrings.ContainsKey(canvasImage.ImageBase64String))
+                    {
+                        fileId = imageBase64EncodedStrings[canvasImage.ImageBase64String];
+                    }
+                    else
+                    {
+                        fileId = Guid.NewGuid();
+                        imageBase64EncodedStrings[canvasImage.ImageBase64String] = fileId;
+                    }
+
+                    var canvasImageDto = new CanvasImageDto
+                    {
+                        Id = canvasImage.Id,
+                        Width = canvasImage.Bounds.Width,
+                        Height = canvasImage.Bounds.Height,
+                        X = canvasImage.Bounds.Left,
+                        Y = canvasImage.Bounds.Top,
+                        LayerIndex = canvasImage.LayerIndex,
+                        FileId = fileId
+                    };
+                    jsonCanvasImages.Add(JsonSerializer.SerializeToNode(canvasImageDto, serializerOptions));
                 }
-
-                var canvasImageDto = new CanvasImageDto
-                {
-                    Id = canvasImage.Id,
-                    Width = canvasImage.Bounds.Width,
-                    Height = canvasImage.Bounds.Height,
-                    X = canvasImage.Bounds.Left,
-                    Y = canvasImage.Bounds.Top,
-                    LayerIndex = canvasImage.LayerIndex,
-                    FileId = fileId
-                };
-                jsonCanvasImages.Add(JsonSerializer.SerializeToNode(canvasImageDto, serializerOptions));
             }
-        }
 
-        var files = new JsonObject();
-        foreach (var (base64String, fileId) in imageBase64EncodedStrings)
-        {
-            files.Add(fileId.ToString(), base64String);
-        }
-
-        var canvasState = new JsonObject
-        {
-            ["elements"] = new JsonObject
+            var files = new JsonObject();
+            foreach (var (base64String, fileId) in imageBase64EncodedStrings)
             {
-                ["strokes"] = jsonCanvasStrokes,
-                ["images"] = jsonCanvasImages
-            },
-            ["files"] = files,
-            ["backgroundColor"] = backgroundColor.ToString()
-        };
-        await streamWriter.WriteAsync(canvasState.ToJsonString(serializerOptions));
+                files.Add(fileId.ToString(), base64String);
+            }
+
+            var canvasState = new JsonObject
+            {
+                ["elements"] = new JsonObject
+                {
+                    ["strokes"] = jsonCanvasStrokes,
+                    ["images"] = jsonCanvasImages
+                },
+                ["files"] = files,
+                ["backgroundColor"] = backgroundColor.ToString()
+            };
+            await streamWriter.WriteAsync(canvasState.ToJsonString(serializerOptions));
+        });
     }
 
     public async Task LoadAsync(Stream stream)

--- a/Scribble/Services/DocumentService/DocumentService.cs
+++ b/Scribble/Services/DocumentService/DocumentService.cs
@@ -8,17 +8,18 @@ using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Avalonia.Threading;
 using Scribble.Dtos;
+using Scribble.Services.CanvasStateService;
 using Scribble.Shared.Lib.CanvasElements;
 using Scribble.Shared.Lib.CanvasElements.Strokes;
 using SkiaSharp;
 
-namespace Scribble.Services;
+namespace Scribble.Services.DocumentService;
 
-public class DocumentService
+public class DocumentService : IDocumentService
 {
-    private readonly CanvasStateService _canvasStateService;
+    private readonly ICanvasStateService _canvasStateService;
 
-    public DocumentService(CanvasStateService canvasStateService)
+    public DocumentService(ICanvasStateService canvasStateService)
     {
         _canvasStateService = canvasStateService;
     }

--- a/Scribble/Services/DocumentService/DocumentService.cs
+++ b/Scribble/Services/DocumentService/DocumentService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
@@ -36,7 +37,7 @@ public class DocumentService : IDocumentService
 
         await Task.Run(async () =>
         {
-            await using var streamWriter = new StreamWriter(stream);
+            await using var streamWriter = new StreamWriter(stream, Encoding.UTF8, leaveOpen: true);
 
             var serializerOptions = new JsonSerializerOptions
             {
@@ -101,7 +102,8 @@ public class DocumentService : IDocumentService
 
     public async Task LoadAsync(Stream stream)
     {
-        using var streamReader = new StreamReader(stream);
+        using var streamReader =
+            new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, leaveOpen: true);
         var json = await streamReader.ReadToEndAsync();
         var canvasState = JsonNode.Parse(json);
         var jsonCanvasElements = canvasState?["elements"]?.AsObject() ??

--- a/Scribble/Services/DocumentService/IDocumentService.cs
+++ b/Scribble/Services/DocumentService/IDocumentService.cs
@@ -1,0 +1,10 @@
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Scribble.Services.DocumentService;
+
+public interface IDocumentService
+{
+    Task SaveAsync(Stream stream);
+    Task LoadAsync(Stream stream);
+}

--- a/Scribble/Services/MultiUserDrawing/IMultiUserDrawingService.cs
+++ b/Scribble/Services/MultiUserDrawing/IMultiUserDrawingService.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Scribble.Shared.Dtos;
+using Scribble.Shared.Lib;
+
+namespace Scribble.Services.MultiUserDrawing;
+
+public interface IMultiUserDrawingService
+{
+    MultiUserDrawingRoom? Room { get; }
+    bool IsConnected { get; }
+
+    // Network events
+    event Action? ConnectionStarted;
+    event Action? ConnectionStopped;
+    event Action<Event>? EventReceived;
+    event Action<string>? CanvasStateRequested;
+    event Action<Queue<Event>>? CanvasStateReceived;
+    event Action<MultiUserDrawingClient, List<MultiUserDrawingClient>>? ClientJoinedRoom;
+    event Action<MultiUserDrawingClient, List<MultiUserDrawingClient>>? ClientLeftRoom;
+    event Action<Message>? MessageReceived;
+    event Action<string>? MessageSent;
+    event Action<MultiUserDrawingRoom?>? RoomChanged;
+
+    // Methods
+    Task JoinRoomAsync(string roomId, string displayName);
+    Task LeaveRoomAsync(string displayName);
+    Task BroadcastEventAsync(Event evt);
+    Task SendCanvasStateToClientAsync(string targetId, Queue<Event> events);
+    Task BroadcastMessageAsync(MessageDto message);
+}

--- a/Scribble/Services/MultiUserDrawing/MultiUserDrawingService.cs
+++ b/Scribble/Services/MultiUserDrawing/MultiUserDrawingService.cs
@@ -8,7 +8,7 @@ using Scribble.Shared.Lib;
 
 namespace Scribble.Services.MultiUserDrawing;
 
-public class MultiUserDrawingService
+public class MultiUserDrawingService : IMultiUserDrawingService
 {
     private readonly HubConnection _connection;
     public MultiUserDrawingRoom? Room { get; private set; }

--- a/Scribble/State/CameraState.cs
+++ b/Scribble/State/CameraState.cs
@@ -42,4 +42,11 @@ public static class CameraState
         matrix = matrix.PostConcat(SKMatrix.CreateTranslation(-WorldOffSetX * Zoom, -WorldOffSetY * Zoom));
         return matrix;
     }
+
+    public static void Reset()
+    {
+        WorldOffSetX = 0;
+        WorldOffSetY = 0;
+        Zoom = 1.0f;
+    }
 }

--- a/Scribble/Tools/PointerTools/ArrowTool/ArrowTool.cs
+++ b/Scribble/Tools/PointerTools/ArrowTool/ArrowTool.cs
@@ -3,7 +3,7 @@ using Avalonia;
 using Avalonia.Input;
 using Avalonia.Media.Imaging;
 using Avalonia.Platform;
-using Scribble.Services;
+using Scribble.Services.CanvasStateService;
 using Scribble.Shared.Lib;
 using SkiaSharp;
 

--- a/Scribble/Tools/PointerTools/EllipseTool/EllipseTool.cs
+++ b/Scribble/Tools/PointerTools/EllipseTool/EllipseTool.cs
@@ -3,7 +3,7 @@ using Avalonia;
 using Avalonia.Input;
 using Avalonia.Media.Imaging;
 using Avalonia.Platform;
-using Scribble.Services;
+using Scribble.Services.CanvasStateService;
 using Scribble.Shared.Lib;
 using SkiaSharp;
 

--- a/Scribble/Tools/PointerTools/EraseTool/EraseTool.cs
+++ b/Scribble/Tools/PointerTools/EraseTool/EraseTool.cs
@@ -1,7 +1,7 @@
 using System;
 using Avalonia;
 using Avalonia.Input;
-using Scribble.Services;
+using Scribble.Services.CanvasStateService;
 using Scribble.Shared.Lib;
 using SkiaSharp;
 

--- a/Scribble/Tools/PointerTools/ImageTool/ImageTool.cs
+++ b/Scribble/Tools/PointerTools/ImageTool/ImageTool.cs
@@ -6,7 +6,7 @@ using Avalonia.Media.Imaging;
 using Avalonia.Platform;
 using Avalonia.Platform.Storage;
 using Avalonia.Threading;
-using Scribble.Services;
+using Scribble.Services.CanvasStateService;
 using Scribble.Services.DialogService;
 using Scribble.Services.FileService;
 using Scribble.Shared.Lib;

--- a/Scribble/Tools/PointerTools/LineTool/LineTool.cs
+++ b/Scribble/Tools/PointerTools/LineTool/LineTool.cs
@@ -3,7 +3,7 @@ using Avalonia;
 using Avalonia.Input;
 using Avalonia.Media.Imaging;
 using Avalonia.Platform;
-using Scribble.Services;
+using Scribble.Services.CanvasStateService;
 using Scribble.Shared.Lib;
 using SkiaSharp;
 

--- a/Scribble/Tools/PointerTools/PanningTool/PanningTool.cs
+++ b/Scribble/Tools/PointerTools/PanningTool/PanningTool.cs
@@ -1,8 +1,8 @@
+using System;
 using Avalonia;
 using Avalonia.Input;
-using Scribble.Services;
+using Scribble.Services.CanvasStateService;
 using Scribble.State;
-using System;
 using SkiaSharp;
 
 namespace Scribble.Tools.PointerTools.PanningTool;

--- a/Scribble/Tools/PointerTools/PencilTool/PencilTool.cs
+++ b/Scribble/Tools/PointerTools/PencilTool/PencilTool.cs
@@ -1,7 +1,7 @@
 using System;
 using Avalonia;
 using Avalonia.Input;
-using Scribble.Services;
+using Scribble.Services.CanvasStateService;
 using Scribble.Shared.Lib;
 using SkiaSharp;
 

--- a/Scribble/Tools/PointerTools/PointerTool.cs
+++ b/Scribble/Tools/PointerTools/PointerTool.cs
@@ -2,7 +2,7 @@ using System;
 using Avalonia.Input;
 using Avalonia.Media.Imaging;
 using Avalonia.Platform;
-using Scribble.Services;
+using Scribble.Services.CanvasStateService;
 using SkiaSharp;
 
 namespace Scribble.Tools.PointerTools;

--- a/Scribble/Tools/PointerTools/RectangleTool/RectangleTool.cs
+++ b/Scribble/Tools/PointerTools/RectangleTool/RectangleTool.cs
@@ -3,7 +3,7 @@ using Avalonia;
 using Avalonia.Input;
 using Avalonia.Media.Imaging;
 using Avalonia.Platform;
-using Scribble.Services;
+using Scribble.Services.CanvasStateService;
 using Scribble.Shared.Lib;
 using SkiaSharp;
 

--- a/Scribble/Tools/PointerTools/SelectTool/SelectTool.cs
+++ b/Scribble/Tools/PointerTools/SelectTool/SelectTool.cs
@@ -3,7 +3,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Media;
-using Scribble.Services;
+using Scribble.Services.CanvasStateService;
 using Scribble.Shared.Lib;
 using Scribble.State;
 using SkiaSharp;

--- a/Scribble/Tools/PointerTools/StrokeTool.cs
+++ b/Scribble/Tools/PointerTools/StrokeTool.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 using Avalonia.Media.Imaging;
-using Scribble.Services;
+using Scribble.Services.CanvasStateService;
 using Scribble.Shared.Lib;
 
 namespace Scribble.Tools.PointerTools;

--- a/Scribble/Tools/PointerTools/TextTool/TextTool.cs
+++ b/Scribble/Tools/PointerTools/TextTool/TextTool.cs
@@ -6,7 +6,7 @@ using Avalonia.Interactivity;
 using Avalonia.Media;
 using Avalonia.Media.Imaging;
 using Avalonia.Platform;
-using Scribble.Services;
+using Scribble.Services.CanvasStateService;
 using Scribble.Shared.Lib;
 using Scribble.Shared.Lib.CanvasElements.Strokes;
 using Scribble.State;

--- a/Scribble/Utils/Utilities.cs
+++ b/Scribble/Utils/Utilities.cs
@@ -62,7 +62,6 @@ public static class Utilities
 
     /// <summary>
     /// Returns true if two points are within a small epsilon of each other.
-    /// Filters subpixel jitter from tablet pens without affecting intentional movement.
     /// </summary>
     public static bool AreSamePosition(SKPoint a, SKPoint b, double epsilon = 0.5)
     {

--- a/Scribble/ViewModels/CanvasExportViewModel.cs
+++ b/Scribble/ViewModels/CanvasExportViewModel.cs
@@ -6,7 +6,7 @@ using Avalonia.Media.Imaging;
 using Avalonia.Platform.Storage;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
-using Scribble.Services;
+using Scribble.Services.CanvasStateService;
 using Scribble.Services.FileService;
 using Scribble.Shared.Lib.CanvasElements;
 using Scribble.Shared.Lib.CanvasElements.Strokes;

--- a/Scribble/ViewModels/DocumentViewModel.cs
+++ b/Scribble/ViewModels/DocumentViewModel.cs
@@ -19,16 +19,18 @@ public partial class DocumentViewModel : ViewModelBase
     private readonly CanvasStateService _canvasStateService;
     private readonly DocumentService _documentService;
     private readonly MultiUserDrawingService _multiUserDrawingService;
+    private readonly AutoSaveService _autoSaveService;
 
     public DocumentViewModel(IFileService fileService, IDialogService dialogService,
         CanvasStateService canvasStateService, DocumentService documentService,
-        MultiUserDrawingService multiUserDrawingService)
+        MultiUserDrawingService multiUserDrawingService, AutoSaveService autoSaveService)
     {
         _fileService = fileService;
         _dialogService = dialogService;
         _canvasStateService = canvasStateService;
         _documentService = documentService;
         _multiUserDrawingService = multiUserDrawingService;
+        _autoSaveService = autoSaveService;
     }
 
     [RelayCommand]
@@ -45,6 +47,7 @@ public partial class DocumentViewModel : ViewModelBase
         {
             await using var stream = await file.OpenWriteAsync();
             await _documentService.SaveAsync(stream);
+            _autoSaveService.DeleteAutoSavedState();
         }
     }
 

--- a/Scribble/ViewModels/DocumentViewModel.cs
+++ b/Scribble/ViewModels/DocumentViewModel.cs
@@ -1,8 +1,10 @@
 using System.Threading.Tasks;
 using Avalonia.Platform.Storage;
 using CommunityToolkit.Mvvm.Input;
-using Scribble.Services;
+using Scribble.Services.AutoSaveService;
+using Scribble.Services.CanvasStateService;
 using Scribble.Services.DialogService;
+using Scribble.Services.DocumentService;
 using Scribble.Services.FileService;
 using Scribble.Services.MultiUserDrawing;
 

--- a/Scribble/ViewModels/MainViewModel.cs
+++ b/Scribble/ViewModels/MainViewModel.cs
@@ -7,7 +7,7 @@ using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
-using Scribble.Services;
+using Scribble.Services.CanvasStateService;
 using Scribble.Services.DialogService;
 using Scribble.Services.MultiUserDrawing;
 using Scribble.Shared.Lib.CanvasElements;

--- a/Scribble/ViewModels/MultiUserDrawingViewModel.cs
+++ b/Scribble/ViewModels/MultiUserDrawingViewModel.cs
@@ -6,7 +6,7 @@ using Avalonia.Media;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
-using Scribble.Services;
+using Scribble.Services.CanvasStateService;
 using Scribble.Services.DialogService;
 using Scribble.Services.MultiUserDrawing;
 using Scribble.Shared.Dtos;

--- a/Scribble/ViewModels/MultiUserDrawingViewModel.cs
+++ b/Scribble/ViewModels/MultiUserDrawingViewModel.cs
@@ -39,7 +39,7 @@ public partial class MultiUserDrawingViewModel : ViewModelBase
     private string _roomId = string.Empty;
 
     [ObservableProperty] [NotifyCanExecuteChangedFor(nameof(ToggleRoomConnectionCommand))]
-    private string _clientDisplayName = "Bootlicker";
+    private string _clientDisplayName = "Archer";
 
     [ObservableProperty] [NotifyCanExecuteChangedFor(nameof(SendMessageCommand))]
     private string _message = string.Empty;
@@ -129,7 +129,7 @@ public partial class MultiUserDrawingViewModel : ViewModelBase
 
         if (string.IsNullOrWhiteSpace(ClientDisplayName))
         {
-            ClientDisplayName = "Bootlicker";
+            ClientDisplayName = "Archer";
         }
 
         var cleanedMessage = Message.Trim();

--- a/Scribble/ViewModels/UiStateViewModel.cs
+++ b/Scribble/ViewModels/UiStateViewModel.cs
@@ -4,7 +4,7 @@ using System.Collections.ObjectModel;
 using Avalonia.Media;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
-using Scribble.Services;
+using Scribble.Services.CanvasStateService;
 using Scribble.Shared.Lib;
 using Scribble.Shared.Lib.CanvasElements;
 using Scribble.Shared.Lib.CanvasElements.Strokes;

--- a/Scribble/Views/MainView.axaml
+++ b/Scribble/Views/MainView.axaml
@@ -798,7 +798,7 @@
                         <TextBlock FontSize="12" TextWrapping="Wrap" Foreground="WhiteSmoke">
                             If the room id doesn't belong to any active room, the room is automatically created
                         </TextBlock>
-                        <TextBlock FontSize="12" TextWrapping="Wrap" Foreground="WhiteSmoke">
+                        <TextBlock FontSize="12" TextWrapping="Wrap" Foreground="WhiteSmoke" FontStyle="Italic">
                             Note: It might take a minute for the initial connection to be established
                         </TextBlock>
                     </StackPanel>

--- a/Scribble/Views/MainView.axaml
+++ b/Scribble/Views/MainView.axaml
@@ -306,7 +306,7 @@
         <StackPanel
             HorizontalAlignment="Right"
             VerticalAlignment="Top"
-            Margin="0, 80, 24, 0"
+            Margin="0, 12, 12, 0"
             Spacing="4">
             <Border
                 Background="#EE2B2B2B"

--- a/Scribble/Views/MainView.axaml
+++ b/Scribble/Views/MainView.axaml
@@ -755,8 +755,8 @@
                                                MaxWidth="400"
                                                Text="{Binding Content}"
                                                Foreground="{Binding IsSent,
-                                               Converter={StaticResource BoolToBrushConverter},
-                                               ConverterParameter=sentStatus}" />
+                                                   Converter={StaticResource BoolToBrushConverter},
+                                                   ConverterParameter=sentStatus}" />
                                 </StackPanel>
                             </DataTemplate>
                         </ListBox.ItemTemplate>

--- a/Scribble/Views/MainView.axaml.cs
+++ b/Scribble/Views/MainView.axaml.cs
@@ -12,7 +12,7 @@ using Avalonia.Skia;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.Input;
 using Microsoft.Extensions.DependencyInjection;
-using Scribble.Services;
+using Scribble.Services.CanvasStateService;
 using Scribble.Services.DialogService;
 using Scribble.Services.FileService;
 using Scribble.Services.MultiUserDrawing;


### PR DESCRIPTION
This pull request introduces a new autosave service and comprehensive suite of unit tests for value converters and SkiaSharp JSON converters, adds necessary test dependencies, and includes supporting files for Avalonia headless testing. It also makes minor improvements to serialization and project configuration.

**Testing Infrastructure and Dependencies**
- Added several testing and mocking packages to `Directory.Packages.props`, including `Avalonia.Headless.XUnit`, `FluentAssertions`, `NSubstitute`, `xunit.v3`, and `coverlet.collector`, to support robust and headless unit testing.
- Added `Scribble.Tests/HeadlessApp.axaml` and `Scribble.Tests/HeadlessApp.axaml.cs` to provide an Avalonia application context for headless UI tests.

**Unit Tests for Value Converters**
- Added thorough unit tests for `BoolToBrushConverter`, `EnumToBoolConverter`, `SKColorJsonConverter`, `SKMatrixJsonConverter`, and `SKPathJsonConverter`, ensuring correct conversion logic, round-trip serialization, and error handling.

**Serialization Improvements**
- Registered `DrawStroke` and `TextStroke` as derived types for polymorphic serialization in `CanvasElement`, improving JSON (de)serialization.
- Added missing `using` directive for `JsonIgnore` and replaced fully qualified attribute with a direct `[JsonIgnore]` on `DrawStroke.RawPoints` for clarity and consistency.

**Project Configuration**
- Changed the `TargetFramework` in `Scribble.Server.csproj` from `net10.0` to `net9.0` for compatibility.

**Code Quality**
- Improved `StrokePaint.Clone()` to ensure `DashIntervals` is properly cloned, preventing shared references.