### PR TITLE
Add integration tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-nuget-
 
-      - name: Run Unit Tests
+      - name: Run All Tests
         # This will fail the job if any test in the solution fails
         run: dotnet test --verbosity normal
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,6 +20,7 @@
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageVersion Include="FluentAssertions" Version="8.10.0" />
     <PackageVersion Include="MessageBox.Avalonia" Version="3.3.1.1" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.17" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.2" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />

--- a/Scribble.IntegrationTests/Hub/HubServerFixture.cs
+++ b/Scribble.IntegrationTests/Hub/HubServerFixture.cs
@@ -1,0 +1,18 @@
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.SignalR.Client;
+
+namespace Scribble.IntegrationTests.Hub;
+
+public class HubServerFixture : WebApplicationFactory<Program>
+{
+    public HubConnection CreateHubConnection()
+    {
+        var handler = Server.CreateHandler();
+        return new HubConnectionBuilder()
+            .WithUrl("http://localhost/drawingHub", opts =>
+            {
+                opts.HttpMessageHandlerFactory = _ => handler;
+            })
+            .Build();
+    }
+}

--- a/Scribble.IntegrationTests/Hub/MultiUserDrawingHubTests.cs
+++ b/Scribble.IntegrationTests/Hub/MultiUserDrawingHubTests.cs
@@ -1,0 +1,307 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.SignalR.Client;
+using Scribble.Shared.Dtos;
+using Scribble.Shared.Lib;
+
+namespace Scribble.IntegrationTests.Hub;
+
+[Collection("HubTests")]
+public class MultiUserDrawingHubTests(HubServerFixture fixture) : IClassFixture<HubServerFixture>, IAsyncLifetime
+{
+    private HubConnection _aliceConnection = null!;
+    private HubConnection _bobConnection = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        _aliceConnection = fixture.CreateHubConnection();
+        _bobConnection = fixture.CreateHubConnection();
+
+        await _aliceConnection.StartAsync();
+        await _bobConnection.StartAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _aliceConnection.StopAsync();
+        await _bobConnection.StopAsync();
+        await _aliceConnection.DisposeAsync();
+        await _bobConnection.DisposeAsync();
+    }
+
+    // -- Room Join --
+
+    [Fact]
+    public async Task JoinRoom_SingleClient_ClientJoinedEventContainsOnlyThatClient()
+    {
+        var roomId = Guid.NewGuid().ToString();
+        var tcs = new TaskCompletionSource<(MultiUserDrawingClient User, List<MultiUserDrawingClient> Users)>();
+
+        _aliceConnection.On<MultiUserDrawingClient, List<MultiUserDrawingClient>>("ClientJoined", (user, users) =>
+        {
+            if (user.Name == "Alice") tcs.TrySetResult((user, users));
+        });
+
+        await _aliceConnection.InvokeAsync("JoinRoom", roomId, "Alice",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var result = await tcs.Task.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
+        result.User.Name.Should().Be("Alice");
+        result.Users.Should().ContainSingle(u => u.Name == "Alice");
+    }
+
+    [Fact]
+    public async Task JoinRoom_TwoClients_BothClientsReceiveClientJoinedWithUpdatedList()
+    {
+        var roomId = Guid.NewGuid().ToString();
+        await _aliceConnection.InvokeAsync("JoinRoom", roomId, "Alice",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var aliceTcs = new TaskCompletionSource<List<MultiUserDrawingClient>>();
+        var bobTcs = new TaskCompletionSource<List<MultiUserDrawingClient>>();
+
+        _aliceConnection.On<MultiUserDrawingClient, List<MultiUserDrawingClient>>("ClientJoined", (user, users) =>
+        {
+            if (user.Name == "Bob") aliceTcs.TrySetResult(users);
+        });
+
+        _bobConnection.On<MultiUserDrawingClient, List<MultiUserDrawingClient>>("ClientJoined", (user, users) =>
+        {
+            if (user.Name == "Bob") bobTcs.TrySetResult(users);
+        });
+
+        await _bobConnection.InvokeAsync("JoinRoom", roomId, "Bob",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var aliceUsers = await aliceTcs.Task.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
+        var bobUsers = await bobTcs.Task.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
+
+        aliceUsers.Should().HaveCount(2).And.Contain(u => u.Name == "Bob");
+        bobUsers.Should().HaveCount(2).And.Contain(u => u.Name == "Alice");
+    }
+
+    [Fact]
+    public async Task JoinRoom_TwoClients_HostReceivesCanvasStateRequest()
+    {
+        var roomId = Guid.NewGuid().ToString();
+        await _aliceConnection.InvokeAsync("JoinRoom", roomId, "Alice",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var hostRequestTcs = new TaskCompletionSource<string>();
+        _aliceConnection.On<string>("RequestCanvasState",
+            newClientConnectionId => { hostRequestTcs.TrySetResult(newClientConnectionId); });
+
+        await _bobConnection.InvokeAsync("JoinRoom", roomId, "Bob",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var targetConnectionId =
+            await hostRequestTcs.Task.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
+        targetConnectionId.Should().Be(_bobConnection.ConnectionId);
+    }
+
+    // -- Disconnect / Leave --
+
+    [Fact]
+    public async Task Disconnect_AfterJoiningRoom_RemainingClientReceivesClientLeftEvent()
+    {
+        var roomId = Guid.NewGuid().ToString();
+        await _aliceConnection.InvokeAsync("JoinRoom", roomId, "Alice",
+            cancellationToken: TestContext.Current.CancellationToken);
+        await _bobConnection.InvokeAsync("JoinRoom", roomId, "Bob",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var aliceTcs = new TaskCompletionSource<MultiUserDrawingClient>();
+        _aliceConnection.On<MultiUserDrawingClient, List<MultiUserDrawingClient>>("ClientLeft",
+            (user, users) => { aliceTcs.TrySetResult(user); });
+
+        // Simulate Bob abruptly disconnecting
+        await _bobConnection.StopAsync(TestContext.Current.CancellationToken);
+
+        var leftUser = await aliceTcs.Task.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
+        leftUser.Name.Should().Be("Bob");
+    }
+
+    [Fact]
+    public async Task LeaveRoom_ClientLeaves_OtherClientReceivesClientLeftEvent()
+    {
+        var roomId = Guid.NewGuid().ToString();
+        await _aliceConnection.InvokeAsync("JoinRoom", roomId, "Alice",
+            cancellationToken: TestContext.Current.CancellationToken);
+        await _bobConnection.InvokeAsync("JoinRoom", roomId, "Bob",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var aliceTcs = new TaskCompletionSource<MultiUserDrawingClient>();
+        _aliceConnection.On<MultiUserDrawingClient, List<MultiUserDrawingClient>>("ClientLeft",
+            (user, users) => { aliceTcs.TrySetResult(user); });
+
+        await _bobConnection.InvokeAsync("LeaveRoom", roomId, "Bob",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var leftUser = await aliceTcs.Task.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
+        leftUser.Name.Should().Be("Bob");
+    }
+
+    // -- Event Routing --
+
+    [Fact]
+    public async Task SendEvent_ToRoom_OtherClientReceivesEvent()
+    {
+        var roomId = Guid.NewGuid().ToString();
+        await _aliceConnection.InvokeAsync("JoinRoom", roomId, "Alice",
+            cancellationToken: TestContext.Current.CancellationToken);
+        await _bobConnection.InvokeAsync("JoinRoom", roomId, "Bob",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var bobEventTcs = new TaskCompletionSource<Event>();
+        _bobConnection.On<Event>("ReceiveEvent", @event => { bobEventTcs.TrySetResult(@event); });
+
+        var testEvent = new EndStrokeEvent(Guid.NewGuid())
+        {
+            CreatorConnectionId = _aliceConnection.ConnectionId
+        };
+
+        await _aliceConnection.InvokeAsync("SendEvent", roomId, testEvent,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var received = await bobEventTcs.Task.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
+        received.Should().BeOfType<EndStrokeEvent>();
+    }
+
+    [Fact]
+    public async Task SendEvent_WithSpoofedCreatorId_EventIsDropped()
+    {
+        var roomId = Guid.NewGuid().ToString();
+        await _aliceConnection.InvokeAsync("JoinRoom", roomId, "Alice",
+            cancellationToken: TestContext.Current.CancellationToken);
+        await _bobConnection.InvokeAsync("JoinRoom", roomId, "Bob",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var bobEventTcs = new TaskCompletionSource<Event>();
+        _bobConnection.On<Event>("ReceiveEvent", @event => { bobEventTcs.TrySetResult(@event); });
+
+        var spoofedEvent = new EndStrokeEvent(Guid.NewGuid())
+        {
+            // Alice pretends to be Bob
+            CreatorConnectionId = _bobConnection.ConnectionId
+        };
+
+        await _aliceConnection.InvokeAsync("SendEvent", roomId, spoofedEvent,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var task = bobEventTcs.Task.WaitAsync(TimeSpan.FromMilliseconds(500), TestContext.Current.CancellationToken);
+        await Assert.ThrowsAsync<TimeoutException>(() => task);
+    }
+
+    // -- Canvas State Relay --
+
+    [Fact]
+    public async Task SendCanvasStateToClient_TargetClientReceivesPayload()
+    {
+        var roomId = Guid.NewGuid().ToString();
+        await _aliceConnection.InvokeAsync("JoinRoom", roomId, "Alice",
+            cancellationToken: TestContext.Current.CancellationToken);
+        await _bobConnection.InvokeAsync("JoinRoom", roomId, "Bob",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var bobStateTcs = new TaskCompletionSource<string>();
+        _bobConnection.On<string>("ReceiveCanvasState", state => { bobStateTcs.TrySetResult(state); });
+
+        const string payload = "mock_serialized_state";
+        await _aliceConnection.InvokeAsync("SendCanvasStateToClient", _bobConnection.ConnectionId, payload,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var receivedState =
+            await bobStateTcs.Task.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
+        receivedState.Should().Be(payload);
+    }
+
+    // -- Chat Messaging --
+
+    [Fact]
+    public async Task SendMessage_ValidContent_OtherClientReceivesMessage()
+    {
+        var roomId = Guid.NewGuid().ToString();
+        await _aliceConnection.InvokeAsync("JoinRoom", roomId, "Alice",
+            cancellationToken: TestContext.Current.CancellationToken);
+        await _bobConnection.InvokeAsync("JoinRoom", roomId, "Bob",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var bobMsgTcs = new TaskCompletionSource<Message>();
+        _bobConnection.On<Message>("ReceiveMessage", message =>
+        {
+            if (message.DisplayName == "Alice") bobMsgTcs.TrySetResult(message);
+        });
+
+        var dto = new MessageDto("msg1", "Alice", "Hello World");
+        await _aliceConnection.InvokeAsync("SendMessage", roomId, dto,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var received = await bobMsgTcs.Task.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
+        received.Content.Should().Be(dto.Content);
+    }
+
+    [Fact]
+    public async Task SendMessage_OwnClient_ReceivesMessageSentAcknowledgement()
+    {
+        var roomId = Guid.NewGuid().ToString();
+        await _aliceConnection.InvokeAsync("JoinRoom", roomId, "Alice",
+            cancellationToken: TestContext.Current.CancellationToken);
+        await _bobConnection.InvokeAsync("JoinRoom", roomId, "Bob",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var ackTcs = new TaskCompletionSource<string>();
+        _aliceConnection.On<string>("MessageSent", msgId => { ackTcs.TrySetResult(msgId); });
+
+        var dto = new MessageDto("msg2", "Alice", "Just to me");
+        await _aliceConnection.InvokeAsync("SendMessage", roomId, dto,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var receivedMsgId = await ackTcs.Task.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
+        receivedMsgId.Should().Be(dto.Id);
+    }
+
+    [Fact]
+    public async Task SendMessage_EmptyContent_IsDropped()
+    {
+        var roomId = Guid.NewGuid().ToString();
+        await _aliceConnection.InvokeAsync("JoinRoom", roomId, "Alice",
+            cancellationToken: TestContext.Current.CancellationToken);
+        await _bobConnection.InvokeAsync("JoinRoom", roomId, "Bob",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var bobMsgTcs = new TaskCompletionSource<Message>();
+        _bobConnection.On<Message>("ReceiveMessage", message =>
+        {
+            if (message.DisplayName == "Alice") bobMsgTcs.TrySetResult(message);
+        });
+
+        var dto = new MessageDto("msg3", "Alice", "   ");
+        await _aliceConnection.InvokeAsync("SendMessage", roomId, dto,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var task = bobMsgTcs.Task.WaitAsync(TimeSpan.FromMilliseconds(500), TestContext.Current.CancellationToken);
+        await Assert.ThrowsAsync<TimeoutException>(() => task);
+    }
+
+    [Fact]
+    public async Task SendMessage_ClientNotInRoom_MessageIsDropped()
+    {
+        var roomId = Guid.NewGuid().ToString();
+        // Alice joins, Bob does NOT join
+        await _aliceConnection.InvokeAsync("JoinRoom", roomId, "Alice",
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var aliceMsgTcs = new TaskCompletionSource<Message>();
+        _aliceConnection.On<Message>("ReceiveMessage", message =>
+        {
+            if (message.DisplayName == "Bob") aliceMsgTcs.TrySetResult(message);
+        });
+
+        // Bob tries to send without joining
+        var dto = new MessageDto("msg4", "Bob", "Intruder!");
+        await _bobConnection.InvokeAsync("SendMessage", roomId, dto,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var task = aliceMsgTcs.Task.WaitAsync(TimeSpan.FromMilliseconds(500), TestContext.Current.CancellationToken);
+        await Assert.ThrowsAsync<TimeoutException>(() => task);
+    }
+}

--- a/Scribble.IntegrationTests/Scribble.IntegrationTests.csproj
+++ b/Scribble.IntegrationTests/Scribble.IntegrationTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
@@ -6,6 +6,12 @@
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Scribble.Shared\Scribble.Shared.csproj"/>
+        <ProjectReference Include="..\Scribble\Scribble.csproj"/>
+        <ProjectReference Include="..\Scribble.Server\Scribble.Server.csproj"/>
+    </ItemGroup>
 
     <ItemGroup>
         <PackageReference Include="Avalonia.Headless.XUnit" />

--- a/Scribble.IntegrationTests/Scribble.IntegrationTests.csproj
+++ b/Scribble.IntegrationTests/Scribble.IntegrationTests.csproj
@@ -1,0 +1,29 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net9.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Avalonia.Headless.XUnit" />
+        <PackageReference Include="coverlet.collector"/>
+        <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+        <PackageReference Include="NSubstitute" />
+        <PackageReference Include="NSubstitute.Analyzers.CSharp">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="xunit.runner.visualstudio"/>
+        <PackageReference Include="xunit.v3"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit"/>
+    </ItemGroup>
+
+</Project>

--- a/Scribble.IntegrationTests/Service/CanvasStateServiceFlowTests.cs
+++ b/Scribble.IntegrationTests/Service/CanvasStateServiceFlowTests.cs
@@ -1,0 +1,173 @@
+using FluentAssertions;
+using NSubstitute;
+using Scribble.Services.CanvasStateService;
+using Scribble.Services.MultiUserDrawing;
+using Scribble.Shared.Lib;
+using Scribble.Shared.Lib.CanvasElements.Strokes;
+using SkiaSharp;
+
+namespace Scribble.IntegrationTests.Service;
+
+public class CanvasStateServiceFlowTests
+{
+    private readonly CanvasStateService _sut;
+
+    public CanvasStateServiceFlowTests()
+    {
+        var mockHubService = Substitute.For<IMultiUserDrawingService>();
+        mockHubService.Room.Returns((MultiUserDrawingRoom?)null);
+        _sut = new CanvasStateService(mockHubService);
+    }
+
+    private static StrokePaint DefaultPaint() => new() { Color = SKColors.Black, StrokeWidth = 2f };
+
+    [Fact]
+    public void DrawUndoRedo_MultiStroke_StateRestored()
+    {
+        // Act 1: Draw first stroke (Line)
+        var action1 = Guid.NewGuid();
+        var stroke1 = Guid.NewGuid();
+        _sut.ApplyEvent(
+            new StartStrokeEvent(action1, stroke1, new SKPoint(0f, 0f), DefaultPaint(), ToolType.Pencil, []));
+        _sut.ApplyEvent(new PencilStrokeLineToEvent(action1, stroke1, new SKPoint(10f, 10f)));
+        _sut.ApplyEvent(new EndStrokeEvent(action1));
+
+        // Act 2: Draw second stroke (Arrow)
+        var action2 = Guid.NewGuid();
+        var stroke2 = Guid.NewGuid();
+        _sut.ApplyEvent(new StartStrokeEvent(action2, stroke2, new SKPoint(20f, 20f), DefaultPaint(), ToolType.Arrow,
+            []));
+        _sut.ApplyEvent(new LineStrokeLineToEvent(action2, stroke2, new SKPoint(30f, 30f)));
+        _sut.ApplyEvent(new EndStrokeEvent(action2));
+
+        // Assert Step 1: Canvas has 2 elements
+        _sut.CanvasElements.Should().HaveCount(2);
+
+        // Act 3: Undo once (removes stroke 2)
+        _sut.Undo();
+        _sut.CanvasElements.Should().HaveCount(1);
+        _sut.CanvasElements[0].Id.Should().Be(stroke1);
+
+        // Act 4: Undo again (removes stroke 1)
+        _sut.Undo();
+        _sut.CanvasElements.Should().BeEmpty();
+
+        // Act 5: Redo (restores stroke 1)
+        _sut.Redo();
+        _sut.CanvasElements.Should().HaveCount(1);
+        _sut.CanvasElements[0].Id.Should().Be(stroke1);
+
+        // Act 6: Redo again (restores stroke 2)
+        _sut.Redo();
+        _sut.CanvasElements.Should().HaveCount(2);
+        _sut.CanvasElements[1].Id.Should().Be(stroke2);
+    }
+
+    [Fact]
+    public void EraseUndoRedo_EraseRestored()
+    {
+        // Setup: Draw a stroke
+        var action1 = Guid.NewGuid();
+        var stroke1 = Guid.NewGuid();
+        var startPoint = new SKPoint(0f, 0f);
+        _sut.ApplyEvent(new StartStrokeEvent(action1, stroke1, startPoint, DefaultPaint(), ToolType.Pencil, []));
+        _sut.ApplyEvent(new PencilStrokeLineToEvent(action1, stroke1, new SKPoint(100f, 100f)));
+        _sut.ApplyEvent(new EndStrokeEvent(action1));
+
+        // Act 1: Erase the stroke
+        var action2 = Guid.NewGuid();
+        _sut.ApplyEvent(new StartEraseStrokeEvent(action2, stroke1, startPoint));
+        _sut.ApplyEvent(new TriggerEraseEvent(action2, stroke1));
+
+        // Assert Step 1: Canvas is empty
+        _sut.CanvasElements.Should().BeEmpty();
+
+        // Act 2: Undo the erase
+        _sut.Undo();
+
+        // Assert Step 2: Stroke is back
+        _sut.CanvasElements.Should().HaveCount(1);
+        _sut.CanvasElements[0].Id.Should().Be(stroke1);
+
+        // Act 3: Redo the erase
+        _sut.Redo();
+
+        // Assert Step 3: Stroke is gone again
+        _sut.CanvasElements.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void SelectMove_AfterUndo_OriginalPositionRestored()
+    {
+        // Setup: Draw a stroke
+        var action1 = Guid.NewGuid();
+        var stroke1 = Guid.NewGuid();
+        _sut.ApplyEvent(new StartStrokeEvent(action1, stroke1, new SKPoint(10f, 10f), DefaultPaint(), ToolType.Pencil,
+            []));
+        _sut.ApplyEvent(new PencilStrokeLineToEvent(action1, stroke1, new SKPoint(50f, 50f)));
+        _sut.ApplyEvent(new EndStrokeEvent(action1));
+
+        // Capture initial position (Midpoint)
+        var stroke = (DrawStroke)_sut.CanvasElements.First(e => e.Id == stroke1);
+        var initialMidpoint = new SKPoint(stroke.Path.TightBounds.MidX, stroke.Path.TightBounds.MidY);
+
+        // Act 1: Select the stroke
+        var action2 = Guid.NewGuid();
+        var boundId = Guid.NewGuid();
+        _sut.ApplyEvent(new CreateSelectionBoundEvent(action2, boundId, new SKPoint(0f, 0f)));
+        _sut.ApplyEvent(new IncreaseSelectionBoundEvent(action2, boundId, new SKPoint(1000f, 1000f)));
+        _sut.ApplyEvent(new EndSelectionEvent(action2, boundId));
+
+        // Act 2: Move the stroke
+        var action3 = Guid.NewGuid();
+        var translation = new SKPoint(100f, 100f);
+        _sut.ApplyEvent(new MoveCanvasElementsEvent(action3, boundId, translation));
+
+        // Assert Step 1: Stroke moved
+        stroke = (DrawStroke)_sut.CanvasElements.First(e => e.Id == stroke1);
+        var movedMidpoint = new SKPoint(stroke.Path.TightBounds.MidX, stroke.Path.TightBounds.MidY);
+        movedMidpoint.X.Should().BeApproximately(initialMidpoint.X + translation.X, precision: 1f);
+
+        // Act 3: Undo the move (action3)
+        _sut.Undo();
+
+        // Assert Step 2: Stroke returned to initial position
+        stroke = (DrawStroke)_sut.CanvasElements.First(e => e.Id == stroke1);
+        var restoredMidpoint = new SKPoint(stroke.Path.TightBounds.MidX, stroke.Path.TightBounds.MidY);
+        restoredMidpoint.X.Should().BeApproximately(initialMidpoint.X, precision: 1f);
+
+        // Act 4: Undo the selection (action2)
+        _sut.Undo();
+
+        // Assert Step 3: Selection is cleared
+        _sut.ActiveSelectionBoundId.Should().BeNull();
+        _sut.GetSelectedElements().Should().BeEmpty();
+    }
+
+    [Fact]
+    public void RemoteEvent_DoesNotPushUndoStack()
+    {
+        // Setup: Remote event arrives from Hub
+        var action1 = Guid.NewGuid();
+        var stroke1 = Guid.NewGuid();
+        var startEvent =
+            new StartStrokeEvent(action1, stroke1, new SKPoint(0f, 0f), DefaultPaint(), ToolType.Pencil, []);
+        var lineEvent = new PencilStrokeLineToEvent(action1, stroke1, new SKPoint(10f, 10f));
+        var endEvent = new EndStrokeEvent(action1);
+
+        // Act 1: Apply remote stroke
+        _sut.ApplyEvent(startEvent, isLocalEvent: false);
+        _sut.ApplyEvent(lineEvent, isLocalEvent: false);
+        _sut.ApplyEvent(endEvent, isLocalEvent: false);
+
+        // Assert Step 1: Canvas has the element
+        _sut.CanvasElements.Should().HaveCount(1);
+        _sut.CanvasElements[0].Id.Should().Be(stroke1);
+
+        // Act 2: Try to Undo
+        _sut.Undo();
+
+        // Assert Step 2: Element remains because remote events do not populate our undo stack
+        _sut.CanvasElements.Should().HaveCount(1);
+    }
+}

--- a/Scribble.IntegrationTests/Service/MultiUserDrawingServiceIntegrationTests.cs
+++ b/Scribble.IntegrationTests/Service/MultiUserDrawingServiceIntegrationTests.cs
@@ -1,0 +1,265 @@
+using FluentAssertions;
+using Scribble.IntegrationTests.Hub;
+using Scribble.Services.MultiUserDrawing;
+using Scribble.Shared.Dtos;
+using Scribble.Shared.Lib;
+
+namespace Scribble.IntegrationTests.Service;
+
+[Collection("HubTests")]
+public class MultiUserDrawingServiceIntegrationTests(HubServerFixture fixture)
+    : IClassFixture<HubServerFixture>, IAsyncLifetime
+{
+    private MultiUserDrawingService _aliceService = null!;
+    private MultiUserDrawingService _bobService = null!;
+
+    public ValueTask InitializeAsync()
+    {
+        // Leverage the internal constructor to bypass standard network pipeline
+        _aliceService = new MultiUserDrawingService(fixture.CreateHubConnection());
+        _bobService = new MultiUserDrawingService(fixture.CreateHubConnection());
+        return ValueTask.CompletedTask;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_aliceService.IsConnected) await _aliceService.LeaveRoomAsync("Alice");
+        if (_bobService.IsConnected) await _bobService.LeaveRoomAsync("Bob");
+    }
+
+    // -- Connection lifecycle --
+
+    [Fact]
+    public async Task JoinRoomAsync_Success_ConnectionStartedEventFires()
+    {
+        var roomId = Guid.NewGuid().ToString();
+        var tcs = new TaskCompletionSource();
+
+        _aliceService.ConnectionStarted += () => tcs.TrySetResult();
+
+        await _aliceService.JoinRoomAsync(roomId, "Alice");
+
+        await tcs.Task.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
+        _aliceService.IsConnected.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task JoinRoomAsync_Success_RoomPropertyIsPopulated()
+    {
+        var roomId = Guid.NewGuid().ToString();
+        await _aliceService.JoinRoomAsync(roomId, "Alice");
+
+        _aliceService.Room.Should().NotBeNull();
+        _aliceService.Room.RoomId.Should().Be(roomId);
+        _aliceService.Room.Me.Name.Should().Be("Alice");
+    }
+
+    [Fact]
+    public async Task JoinRoomAsync_Success_RoomChangedEventFiresWithRoom()
+    {
+        var roomId = Guid.NewGuid().ToString();
+        var tcs = new TaskCompletionSource<MultiUserDrawingRoom?>();
+
+        _aliceService.RoomChanged += room =>
+        {
+            if (room != null && room.RoomId == roomId) tcs.TrySetResult(room);
+        };
+
+        await _aliceService.JoinRoomAsync(roomId, "Alice");
+
+        var roomResult = await tcs.Task.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
+        roomResult.Should().NotBeNull();
+        roomResult.RoomId.Should().Be(roomId);
+    }
+
+    [Fact]
+    public async Task LeaveRoomAsync_AfterJoining_RoomChangedEventFiresWithNull()
+    {
+        var roomId = Guid.NewGuid().ToString();
+        await _aliceService.JoinRoomAsync(roomId, "Alice");
+
+        var tcs = new TaskCompletionSource<MultiUserDrawingRoom?>();
+        _aliceService.RoomChanged += room =>
+        {
+            if (room == null) tcs.TrySetResult(room);
+        };
+
+        await _aliceService.LeaveRoomAsync("Alice");
+
+        var roomResult = await tcs.Task.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
+        roomResult.Should().BeNull();
+        _aliceService.IsConnected.Should().BeFalse();
+        _aliceService.Room.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task JoinRoomAsync_InvalidServer_RoomRemainsNull()
+    {
+        var invalidService = new MultiUserDrawingService("http://localhost:9999/badurl");
+
+        await invalidService.JoinRoomAsync("room", "Alice");
+
+        invalidService.Room.Should().BeNull();
+        invalidService.IsConnected.Should().BeFalse();
+    }
+
+    // -- Event Relay --
+
+    [Fact]
+    public async Task BroadcastEventAsync_SecondClientInRoom_EventReceivedEventFires()
+    {
+        var roomId = Guid.NewGuid().ToString();
+        await _aliceService.JoinRoomAsync(roomId, "Alice");
+        await _bobService.JoinRoomAsync(roomId, "Bob");
+
+        var bobEventTcs = new TaskCompletionSource<Event>();
+        _bobService.EventReceived += evt => { bobEventTcs.TrySetResult(evt); };
+
+        var endStrokeEvent = new EndStrokeEvent(Guid.NewGuid());
+        await _aliceService.BroadcastEventAsync(endStrokeEvent);
+
+        var receivedEvt =
+            await bobEventTcs.Task.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
+        receivedEvt.Should().BeOfType<EndStrokeEvent>();
+    }
+
+    [Fact]
+    public async Task BroadcastEventAsync_ToEmptyRoom_NoException()
+    {
+        var roomId = Guid.NewGuid().ToString();
+        await _aliceService.JoinRoomAsync(roomId, "Alice");
+
+        var act = async () => await _aliceService.BroadcastEventAsync(new EndStrokeEvent(Guid.NewGuid()));
+        await act.Should().NotThrowAsync();
+    }
+
+    // -- Canvas State Handshake --
+
+    [Fact]
+    public async Task JoinRoomAsync_AsSecondClient_CanvasStateRequestedFiresOnHost()
+    {
+        var roomId = Guid.NewGuid().ToString();
+        await _aliceService.JoinRoomAsync(roomId, "Alice");
+
+        var aliceRequestTcs = new TaskCompletionSource<string>();
+        _aliceService.CanvasStateRequested += targetClientConnectionId =>
+        {
+            aliceRequestTcs.TrySetResult(targetClientConnectionId);
+        };
+
+        await _bobService.JoinRoomAsync(roomId, "Bob");
+
+        var requestClientConnectionId =
+            await aliceRequestTcs.Task.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
+        requestClientConnectionId.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task SendCanvasStateToClientAsync_TargetClient_CanvasStateReceivedFires()
+    {
+        var roomId = Guid.NewGuid().ToString();
+        await _aliceService.JoinRoomAsync(roomId, "Alice");
+
+        var aliceRequestTcs = new TaskCompletionSource<string>();
+        _aliceService.CanvasStateRequested += targetClientConnectionId =>
+        {
+            aliceRequestTcs.TrySetResult(targetClientConnectionId);
+        };
+
+        var bobStateTcs = new TaskCompletionSource<Queue<Event>>();
+        _bobService.CanvasStateReceived += events => { bobStateTcs.TrySetResult(events); };
+
+        await _bobService.JoinRoomAsync(roomId, "Bob");
+        var bobConnectionId =
+            await aliceRequestTcs.Task.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
+
+        var queue = new Queue<Event>();
+        queue.Enqueue(new EndStrokeEvent(Guid.NewGuid()));
+
+        await _aliceService.SendCanvasStateToClientAsync(bobConnectionId, queue);
+
+        var receivedQueue =
+            await bobStateTcs.Task.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
+        receivedQueue.Should().HaveCount(1);
+    }
+
+    // -- Room membership events --
+
+    [Fact]
+    public async Task JoinRoomAsync_TwoClients_ClientJoinedRoomEventFiresOnFirst()
+    {
+        var roomId = Guid.NewGuid().ToString();
+        await _aliceService.JoinRoomAsync(roomId, "Alice");
+
+        var aliceTcs = new TaskCompletionSource<(MultiUserDrawingClient User, List<MultiUserDrawingClient> Users)>();
+        _aliceService.ClientJoinedRoom += (user, users) =>
+        {
+            if (user.Name == "Bob") aliceTcs.TrySetResult((user, users));
+        };
+
+        await _bobService.JoinRoomAsync(roomId, "Bob");
+
+        var result = await aliceTcs.Task.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
+        result.User.Name.Should().Be("Bob");
+        result.Users.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task LeaveRoomAsync_SecondClientLeaves_ClientLeftRoomEventFiresOnFirst()
+    {
+        var roomId = Guid.NewGuid().ToString();
+        await _aliceService.JoinRoomAsync(roomId, "Alice");
+        await _bobService.JoinRoomAsync(roomId, "Bob");
+
+        var aliceTcs = new TaskCompletionSource<(MultiUserDrawingClient User, List<MultiUserDrawingClient> Users)>();
+        _aliceService.ClientLeftRoom += (user, users) =>
+        {
+            if (user.Name == "Bob") aliceTcs.TrySetResult((user, users));
+        };
+
+        await _bobService.LeaveRoomAsync("Bob");
+
+        var result = await aliceTcs.Task.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
+        result.User.Name.Should().Be("Bob");
+        result.Users.Should().HaveCount(1); // Only Alice left in the room
+    }
+
+    // -- Chat --
+
+    [Fact]
+    public async Task BroadcastMessageAsync_RecipientReceivesMessage_MessageReceivedFires()
+    {
+        var roomId = Guid.NewGuid().ToString();
+        await _aliceService.JoinRoomAsync(roomId, "Alice");
+        await _bobService.JoinRoomAsync(roomId, "Bob");
+
+        var bobMsgTcs = new TaskCompletionSource<Message>();
+        _bobService.MessageReceived += msg =>
+        {
+            if (msg.DisplayName == "Alice") bobMsgTcs.TrySetResult(msg);
+        };
+
+        var dto = new MessageDto("msg1", "Alice", "Hello World");
+        await _aliceService.BroadcastMessageAsync(dto);
+
+        var msg = await bobMsgTcs.Task.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
+        msg.Content.Should().Be("Hello World");
+    }
+
+    [Fact]
+    public async Task BroadcastMessageAsync_SenderReceivesAck_MessageSentFires()
+    {
+        var roomId = Guid.NewGuid().ToString();
+        await _aliceService.JoinRoomAsync(roomId, "Alice");
+        await _bobService.JoinRoomAsync(roomId, "Bob");
+
+        var aliceAckTcs = new TaskCompletionSource<string>();
+        _aliceService.MessageSent += msgId => { aliceAckTcs.TrySetResult(msgId); };
+
+        var dto = new MessageDto("msg2", "Alice", "Just sent this");
+        await _aliceService.BroadcastMessageAsync(dto);
+
+        var msgId = await aliceAckTcs.Task.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
+        msgId.Should().Be(dto.Id);
+    }
+}

--- a/Scribble.IntegrationTests/Tools/PointerToolsIntegrationTests.cs
+++ b/Scribble.IntegrationTests/Tools/PointerToolsIntegrationTests.cs
@@ -1,0 +1,220 @@
+using FluentAssertions;
+using NSubstitute;
+using Scribble.Services.CanvasStateService;
+using Scribble.Services.MultiUserDrawing;
+using Scribble.Shared.Lib;
+using Scribble.Shared.Lib.CanvasElements;
+using Scribble.Shared.Lib.CanvasElements.Strokes;
+using SkiaSharp;
+
+namespace Scribble.IntegrationTests.Tools;
+
+public class PointerToolsIntegrationTests
+{
+    private readonly CanvasStateService _sut;
+
+    public PointerToolsIntegrationTests()
+    {
+        var mockHubService = Substitute.For<IMultiUserDrawingService>();
+        mockHubService.Room.Returns((MultiUserDrawingRoom?)null);
+        _sut = new CanvasStateService(mockHubService);
+    }
+
+    private static StrokePaint DefaultPaint() => new() { Color = SKColors.Black, StrokeWidth = 2f };
+
+    [Fact]
+    public void PencilFlow_GeneratesContinuousPath()
+    {
+        var actionId = Guid.NewGuid();
+        var strokeId = Guid.NewGuid();
+
+        _sut.ApplyEvent(new StartStrokeEvent(actionId, strokeId, new SKPoint(0f, 0f), DefaultPaint(), ToolType.Pencil,
+            []));
+        _sut.ApplyEvent(new PencilStrokeLineToEvent(actionId, strokeId, new SKPoint(10f, 10f)));
+        _sut.ApplyEvent(new PencilStrokeLineToEvent(actionId, strokeId, new SKPoint(20f, 15f)));
+        _sut.ApplyEvent(new EndStrokeEvent(actionId));
+
+        var element = _sut.CanvasElements.Should().ContainSingle().Subject;
+        var stroke = element.Should().BeOfType<DrawStroke>().Subject;
+        stroke.ToolType.Should().Be(ToolType.Pencil);
+
+        // Fast path for pencil rebuilds the path, so point count should be > 1
+        stroke.Path.PointCount.Should().BeGreaterThan(1);
+        stroke.Path.TightBounds.Width.Should().BeGreaterThan(0);
+        stroke.Path.TightBounds.Height.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public void LineFlow_GeneratesStraightLineToEndpoint()
+    {
+        var actionId = Guid.NewGuid();
+        var strokeId = Guid.NewGuid();
+        var startPoint = new SKPoint(10f, 10f);
+        var endPoint = new SKPoint(100f, 100f);
+
+        _sut.ApplyEvent(new StartStrokeEvent(actionId, strokeId, startPoint, DefaultPaint(), ToolType.Line, []));
+        _sut.ApplyEvent(new LineStrokeLineToEvent(actionId, strokeId, endPoint));
+        _sut.ApplyEvent(new EndStrokeEvent(actionId));
+
+        var stroke = _sut.CanvasElements.Should().ContainSingle().Subject.Should().BeOfType<DrawStroke>().Subject;
+        stroke.ToolType.Should().Be(ToolType.Line);
+
+        // The path should contain the endpoint
+        stroke.Path.Points.Should().Contain(p =>
+            Math.Abs(p.X - endPoint.X) < 0.1f && Math.Abs(p.Y - endPoint.Y) < 0.1f);
+    }
+
+    [Fact]
+    public void ArrowFlow_GeneratesPathWithArrowHead()
+    {
+        var actionId = Guid.NewGuid();
+        var strokeId = Guid.NewGuid();
+        var startPoint = new SKPoint(50f, 50f);
+        var endPoint = new SKPoint(200f, 50f);
+
+        _sut.ApplyEvent(new StartStrokeEvent(actionId, strokeId, startPoint, DefaultPaint(), ToolType.Arrow, []));
+        _sut.ApplyEvent(new LineStrokeLineToEvent(actionId, strokeId, endPoint));
+        _sut.ApplyEvent(new EndStrokeEvent(actionId));
+
+        var stroke = _sut.CanvasElements.Should().ContainSingle().Subject.Should().BeOfType<DrawStroke>().Subject;
+        stroke.ToolType.Should().Be(ToolType.Arrow);
+
+        // Arrow paths have more points than a simple straight line because of the arrowhead lines
+        stroke.Path.PointCount.Should().BeGreaterThan(2);
+    }
+
+    [Fact]
+    public void EllipseFlow_GeneratesEllipseWithinBoundingBox()
+    {
+        var actionId = Guid.NewGuid();
+        var strokeId = Guid.NewGuid();
+        var startPoint = new SKPoint(0f, 0f);
+        var endPoint = new SKPoint(100f, 50f);
+
+        _sut.ApplyEvent(new StartStrokeEvent(actionId, strokeId, startPoint, DefaultPaint(), ToolType.Ellipse, []));
+        _sut.ApplyEvent(new LineStrokeLineToEvent(actionId, strokeId, endPoint));
+        _sut.ApplyEvent(new EndStrokeEvent(actionId));
+
+        var stroke = _sut.CanvasElements.Should().ContainSingle().Subject.Should().BeOfType<DrawStroke>().Subject;
+        stroke.ToolType.Should().Be(ToolType.Ellipse);
+
+        var bounds = stroke.Path.TightBounds;
+        bounds.Width.Should().BeApproximately(100f, precision: 5f);
+        bounds.Height.Should().BeApproximately(50f, precision: 5f);
+    }
+
+    [Fact]
+    public void RectangleFlow_GeneratesRectGeometry()
+    {
+        var actionId = Guid.NewGuid();
+        var strokeId = Guid.NewGuid();
+        var startPoint = new SKPoint(10f, 10f);
+        var endPoint = new SKPoint(110f, 60f);
+
+        _sut.ApplyEvent(new StartStrokeEvent(actionId, strokeId, startPoint, DefaultPaint(), ToolType.Rectangle, []));
+        _sut.ApplyEvent(new LineStrokeLineToEvent(actionId, strokeId, endPoint));
+        _sut.ApplyEvent(new EndStrokeEvent(actionId));
+
+        var stroke = _sut.CanvasElements.Should().ContainSingle().Subject.Should().BeOfType<DrawStroke>().Subject;
+        stroke.ToolType.Should().Be(ToolType.Rectangle);
+
+        var bounds = stroke.Path.TightBounds;
+        bounds.Width.Should().BeApproximately(100f, precision: 5f);
+        bounds.Height.Should().BeApproximately(50f, precision: 5f);
+    }
+
+    [Fact]
+    public void TextFlow_PreservesTextProperties()
+    {
+        var actionId = Guid.NewGuid();
+        var strokeId = Guid.NewGuid();
+        var position = new SKPoint(50f, 50f);
+        var textContent = "Integration Test String";
+
+        _sut.ApplyEvent(new AddTextEvent(actionId, strokeId, position, textContent, new StrokePaint { TextSize = 24f },
+            []));
+
+        var textElement = _sut.CanvasElements.Should().ContainSingle().Subject.Should().BeOfType<TextStroke>().Subject;
+        textElement.Text.Should().Be(textContent);
+        textElement.Position.X.Should().BeApproximately(position.X, 0.1f);
+        textElement.Position.Y.Should().BeApproximately(position.Y, 0.1f);
+        textElement.Paint.TextSize.Should().Be(24f);
+    }
+
+    [Fact]
+    public void EraseFlow_RemovesTargetedElement()
+    {
+        // Draw a rectangle to act as target
+        var rectAction = Guid.NewGuid();
+        var rectId = Guid.NewGuid();
+        _sut.ApplyEvent(new StartStrokeEvent(rectAction, rectId, new SKPoint(0f, 0f), DefaultPaint(),
+            ToolType.Rectangle, []));
+        _sut.ApplyEvent(new LineStrokeLineToEvent(rectAction, rectId, new SKPoint(100f, 100f)));
+        _sut.ApplyEvent(new EndStrokeEvent(rectAction));
+
+        _sut.CanvasElements.Should().HaveCount(1);
+
+        // Erase the rectangle
+        var eraseAction = Guid.NewGuid();
+        var eraseId = Guid.NewGuid();
+        _sut.ApplyEvent(new StartEraseStrokeEvent(eraseAction, eraseId, new SKPoint(-10f, 50f)));
+        _sut.ApplyEvent(new EraseStrokeLineToEvent(eraseAction, eraseId, new SKPoint(110f, 50f))); // Swipe across
+        _sut.ApplyEvent(new TriggerEraseEvent(eraseAction, eraseId)); // Execute erase
+
+        _sut.CanvasElements.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void SelectFlow_CapturesAndTransformsElement()
+    {
+        // Draw target
+        var strokeAction = Guid.NewGuid();
+        var strokeId = Guid.NewGuid();
+        _sut.ApplyEvent(new StartStrokeEvent(strokeAction, strokeId, new SKPoint(50f, 50f), DefaultPaint(),
+            ToolType.Ellipse, []));
+        _sut.ApplyEvent(new LineStrokeLineToEvent(strokeAction, strokeId, new SKPoint(150f, 150f)));
+        _sut.ApplyEvent(new EndStrokeEvent(strokeAction));
+
+        var initialBounds = ((DrawStroke)_sut.CanvasElements[0]).Path.TightBounds;
+
+        // Select target
+        var selectAction = Guid.NewGuid();
+        var boundId = Guid.NewGuid();
+        _sut.ApplyEvent(new CreateSelectionBoundEvent(selectAction, boundId, new SKPoint(0f, 0f)));
+        _sut.ApplyEvent(new IncreaseSelectionBoundEvent(selectAction, boundId,
+            new SKPoint(200f, 200f))); // Envelopes the ellipse
+        _sut.ApplyEvent(new EndSelectionEvent(selectAction, boundId));
+
+        _sut.ActiveSelectionBoundId.Should().Be(boundId);
+        _sut.SelectedElementIds.Should().Contain(strokeId);
+
+        // Move target
+        var transformAction = Guid.NewGuid();
+        var delta = new SKPoint(200f, 0f);
+        _sut.ApplyEvent(new MoveCanvasElementsEvent(transformAction, boundId, delta));
+
+        var transformedBounds = ((DrawStroke)_sut.CanvasElements[0]).Path.TightBounds;
+        transformedBounds.MidX.Should().BeApproximately(initialBounds.MidX + delta.X, 1f);
+    }
+
+    [Fact]
+    public void ImageFlow_InstantiatesImageNodeWithBounds()
+    {
+        var actionId = Guid.NewGuid();
+        var imageId = Guid.NewGuid();
+        const string base64Dummy =
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="; // 1x1 transparent png
+        var position = new SKPoint(100f, 100f);
+        var size = new SKSize(500f, 300f);
+
+        _sut.ApplyEvent(new AddImageEvent(actionId, imageId, base64Dummy, position, size));
+
+        var imageElement = _sut.CanvasElements.Should().ContainSingle().Subject.Should().BeOfType<CanvasImage>()
+            .Subject;
+        imageElement.ImageBase64String.Should().Be(base64Dummy);
+        imageElement.Bounds.Left.Should().Be(position.X);
+        imageElement.Bounds.Top.Should().Be(position.Y);
+        imageElement.Bounds.Width.Should().Be(size.Width);
+        imageElement.Bounds.Height.Should().Be(size.Height);
+    }
+}

--- a/Scribble.Server/Program.cs
+++ b/Scribble.Server/Program.cs
@@ -25,3 +25,5 @@ app.UseCors();
 app.MapHub<MultiUserDrawingHub>("/drawingHub");
 app.MapGet("/health", () => Results.Ok("Server is awake"));
 app.Run();
+
+public partial class Program { }

--- a/Scribble.slnx
+++ b/Scribble.slnx
@@ -4,10 +4,8 @@
     <File Path="deploy_windows.sh" />
     <File Path="Directory.Packages.props" />
   </Folder>
-<!--  <Project Path="Scribble.Android/Scribble.Android.csproj" />-->
-<!--  <Project Path="Scribble.Browser/Scribble.Browser.csproj" />-->
   <Project Path="Scribble.Desktop/Scribble.Desktop.csproj" />
-<!--  <Project Path="Scribble.iOS/Scribble.iOS.csproj" />-->
+  <Project Path="Scribble.IntegrationTests/Scribble.IntegrationTests.csproj" />
   <Project Path="Scribble.Server/Scribble.Server.csproj" />
   <Project Path="Scribble.Shared/Scribble.Shared.csproj" />
   <Project Path="Scribble.UnitTests/Scribble.UnitTests.csproj" />

--- a/Scribble/Scribble.csproj
+++ b/Scribble/Scribble.csproj
@@ -46,5 +46,6 @@
 
     <ItemGroup>
         <InternalsVisibleTo Include="Scribble.UnitTests" />
+        <InternalsVisibleTo Include="Scribble.IntegrationTests" />
     </ItemGroup>
 </Project>

--- a/Scribble/Services/MultiUserDrawing/MultiUserDrawingService.cs
+++ b/Scribble/Services/MultiUserDrawing/MultiUserDrawingService.cs
@@ -30,7 +30,17 @@ public class MultiUserDrawingService : IMultiUserDrawingService
     public MultiUserDrawingService(string serverUrl)
     {
         _connection = new HubConnectionBuilder().WithUrl(serverUrl).Build();
+        RegisterEventHandlers();
+    }
 
+    internal MultiUserDrawingService(HubConnection connection)
+    {
+        _connection = connection;
+        RegisterEventHandlers();
+    }
+
+    private void RegisterEventHandlers()
+    {
         // Listen for draw events from others in the room
         _connection.On<Event>("ReceiveEvent", @event => { EventReceived?.Invoke(@event); });
 


### PR DESCRIPTION
This pull request introduces a new integration test suite for the project, focusing on end-to-end testing of the multi-user drawing hub and canvas state service. It adds the infrastructure and tests necessary to verify real-time collaboration features, including room joining, event routing, undo/redo flows, and chat messaging.

**Integration Test Infrastructure and Tests:**

* Added a new integration test project (`Scribble.IntegrationTests`) with references to core projects and required test packages, enabling comprehensive integration and flow testing.
* Introduced `HubServerFixture` to spin up a test server and create SignalR hub connections for integration tests.
* Added `MultiUserDrawingHubTests` to verify collaborative hub behaviors, including room joining, disconnects, event routing, canvas state relay, and chat messaging, covering both valid and invalid scenarios.
* Added `CanvasStateServiceFlowTests` to test undo/redo, erase, selection, move, and remote event handling logic in the canvas state service.

**Dependency and Workflow Updates:**

* Added `Microsoft.AspNetCore.Mvc.Testing` to `Directory.Packages.props` to support in-memory server testing.
* Updated the GitHub Actions workflow to run all tests (not just unit tests), ensuring integration tests are executed in CI.

This PR closes #112 and #113 