### PR TITLE
Implement copy and paste

### DIFF
--- a/Scribble.Shared/Lib/CanvasElements/CanvasElement.cs
+++ b/Scribble.Shared/Lib/CanvasElements/CanvasElement.cs
@@ -26,3 +26,11 @@ public abstract class CanvasElement
     /// </summary>
     public DateTime CreatedAt { get; init; } = DateTime.UtcNow;
 }
+
+public interface ICopyable
+{
+    /// <summary>
+    /// Returns a deep copy of this element.
+    /// </summary>
+    CanvasElement Copy();
+}

--- a/Scribble.Shared/Lib/CanvasElements/CanvasImage.cs
+++ b/Scribble.Shared/Lib/CanvasElements/CanvasImage.cs
@@ -3,7 +3,7 @@ using SkiaSharp;
 
 namespace Scribble.Shared.Lib.CanvasElements;
 
-public class CanvasImage : CanvasElement
+public class CanvasImage : CanvasElement, ICopyable
 {
     public required string ImageBase64String { get; init; }
 
@@ -56,5 +56,19 @@ public class CanvasImage : CanvasElement
     {
         _cachedBitmap?.Dispose();
         _cachedBitmap = null;
+    }
+
+    public CanvasElement Copy()
+    {
+        return new CanvasImage
+        {
+            ImageBase64String = ImageBase64String,
+            Bounds = _bounds,
+            Rotation = Rotation,
+            FlipX = FlipX,
+            FlipY = FlipY,
+            CreatorConnectionId = CreatorConnectionId,
+            LayerIndex = LayerIndex
+        };
     }
 }

--- a/Scribble.Shared/Lib/CanvasElements/Strokes/DrawStroke.cs
+++ b/Scribble.Shared/Lib/CanvasElements/Strokes/DrawStroke.cs
@@ -1,11 +1,12 @@
 using System.Text.Json.Serialization;
+using Avalonia.Skia;
 
 namespace Scribble.Shared.Lib.CanvasElements.Strokes;
 
 /// <summary>
 /// Represents a non-text stroke on the canvas (lines, arrows, rectangles, ellipses)
 /// </summary>
-public class DrawStroke : PaintableStroke
+public class DrawStroke : PaintableStroke, ICopyable
 {
     /// <summary>
     /// The Tool that produced the stroke
@@ -17,4 +18,18 @@ public class DrawStroke : PaintableStroke
     /// </summary>
     [JsonIgnore]
     public List<StrokePoint> RawPoints { get; init; } = [];
+
+    public CanvasElement Copy()
+    {
+        return new DrawStroke
+        {
+            ToolType = ToolType,
+            Path = Path.Clone(),
+            ToolOptions = ToolOptions,
+            Paint = Paint.Clone(),
+            RawPoints = [..RawPoints],
+            LayerIndex = LayerIndex,
+            CreatorConnectionId = CreatorConnectionId
+        };
+    }
 }

--- a/Scribble.Shared/Lib/CanvasElements/Strokes/TextStroke.cs
+++ b/Scribble.Shared/Lib/CanvasElements/Strokes/TextStroke.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using Avalonia.Skia;
 using Scribble.Shared.Converters;
 using SkiaSharp;
 
@@ -8,7 +9,7 @@ namespace Scribble.Shared.Lib.CanvasElements.Strokes;
 /// Represents a text element on the canvas. Stores the raw text and its original
 /// baseline position, in addition to the rendered SKPath inherited from Stroke.
 /// </summary>
-public class TextStroke : PaintableStroke
+public class TextStroke : PaintableStroke, ICopyable
 {
     /// <summary>
     /// The text content of this stroke.
@@ -50,6 +51,23 @@ public class TextStroke : PaintableStroke
             if (IsItalic) return SKFontStyle.Italic;
             return SKFontStyle.Normal;
         }
+    }
+
+    public CanvasElement Copy()
+    {
+        return new TextStroke
+        {
+            Text = Text,
+            Position = Position,
+            Path = Path.Clone(),
+            ToolOptions = ToolOptions,
+            Paint = Paint.Clone(),
+            CreatorConnectionId = CreatorConnectionId,
+            LayerIndex = LayerIndex,
+            TransformMatrix = TransformMatrix,
+            IsBold = IsBold,
+            IsItalic = IsItalic,
+        };
     }
 }
 

--- a/Scribble.Shared/Lib/Event.cs
+++ b/Scribble.Shared/Lib/Event.cs
@@ -39,6 +39,7 @@ namespace Scribble.Shared.Lib;
 [JsonDerivedType(typeof(UpdateTextEvent), typeDiscriminator: "UpdateTextEvent")]
 [JsonDerivedType(typeof(UpdateFontCasingEvent), typeDiscriminator: "UpdateFontCasingEvent")]
 [JsonDerivedType(typeof(UpdateFontStyleEvent), typeDiscriminator: "UpdateFontStyleEvent")]
+[JsonDerivedType(typeof(PasteCanvasElementsEvent), typeDiscriminator: "PasteCanvasElementsEvent")]
 public abstract record Event(Guid ActionId)
 {
     public DateTime TimeStamp { get; init; } = DateTime.UtcNow;
@@ -157,4 +158,7 @@ public record UpdateFontCasingEvent(Guid ActionId, List<Guid> TextStrokeIds, Fon
     : Event(ActionId), ITerminalEvent;
 
 public record UpdateFontStyleEvent(Guid ActionId, List<Guid> TextStrokeIds, FontStyle NewStyle)
+    : Event(ActionId), ITerminalEvent;
+
+public record PasteCanvasElementsEvent(Guid ActionId, SKPoint Position, List<CanvasElement> CopiedElements)
     : Event(ActionId), ITerminalEvent;

--- a/Scribble.Shared/Lib/Event.cs
+++ b/Scribble.Shared/Lib/Event.cs
@@ -160,5 +160,5 @@ public record UpdateFontCasingEvent(Guid ActionId, List<Guid> TextStrokeIds, Fon
 public record UpdateFontStyleEvent(Guid ActionId, List<Guid> TextStrokeIds, FontStyle NewStyle)
     : Event(ActionId), ITerminalEvent;
 
-public record PasteCanvasElementsEvent(Guid ActionId, SKPoint Position, List<CanvasElement> CopiedElements)
+public record PasteCanvasElementsEvent(Guid ActionId, SKPoint Position, List<CanvasElement> CopiedElements, Guid SelectionBoundId)
     : Event(ActionId), ITerminalEvent;

--- a/Scribble.Shared/Lib/StrokePaint.cs
+++ b/Scribble.Shared/Lib/StrokePaint.cs
@@ -40,6 +40,7 @@ public class StrokePaint
     {
         var clone = (StrokePaint)MemberwiseClone();
         clone.DashIntervals = DashIntervals?.ToArray();
+        clone._cachedSkPaint = null;
         return clone;
     }
 

--- a/Scribble.Shared/Scribble.Shared.csproj
+++ b/Scribble.Shared/Scribble.Shared.csproj
@@ -7,6 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Avalonia.Skia" />
         <PackageReference Include="SkiaSharp"/>
     </ItemGroup>
 

--- a/Scribble.UnitTests/UtilsTests/UtilitiesTests.cs
+++ b/Scribble.UnitTests/UtilsTests/UtilitiesTests.cs
@@ -1,6 +1,9 @@
 using Avalonia;
 using Avalonia.Media;
 using FluentAssertions;
+using Scribble.Shared.Lib;
+using Scribble.Shared.Lib.CanvasElements;
+using Scribble.Shared.Lib.CanvasElements.Strokes;
 using Scribble.Utils;
 using SkiaSharp;
 
@@ -275,5 +278,84 @@ public class UtilitiesTests
         var actual = Utilities.IsPointNearLine(point, [start, start], tolerance: 1f);
 
         actual.Should().BeFalse();
+    }
+
+    // GetElementsBounds
+    [Fact]
+    public void GetElementsBounds_EmptyList_ReturnsEmptyRect()
+    {
+        var elements = new List<CanvasElement>();
+
+        var actual = Utilities.GetElementsBounds(elements);
+
+        actual.Should().Be(SKRect.Empty);
+    }
+
+    [Fact]
+    public void GetElementsBounds_SingleStroke_ReturnsStrokeBoundsInflatedByHalfStrokeWidth()
+    {
+        var path = new SKPath();
+        path.MoveTo(10f, 10f);
+        path.LineTo(50f, 50f);
+
+        var stroke = new DrawStroke
+        {
+            Id = Guid.NewGuid(),
+            Path = path,
+            Paint = new StrokePaint { StrokeWidth = 4f },
+            ToolType = ToolType.Pencil,
+            ToolOptions = []
+        };
+
+        var actual = Utilities.GetElementsBounds([stroke]);
+        var expected = SKRect.Inflate(path.Bounds, 2f, 2f);
+
+        actual.Should().Be(expected);
+    }
+
+    [Fact]
+    public void GetElementsBounds_SingleImage_ReturnsImageBounds()
+    {
+        var image = new CanvasImage
+        {
+            Id = Guid.NewGuid(),
+            Bounds = new SKRect(15f, 20f, 65f, 90f),
+            ImageBase64String = "BASE64"
+        };
+
+        var actual = Utilities.GetElementsBounds([image]);
+
+        actual.Should().Be(image.Bounds);
+    }
+
+    [Fact]
+    public void GetElementsBounds_MultipleElements_ReturnsUnionOfBounds()
+    {
+        var path = new SKPath();
+        path.MoveTo(10f, 10f);
+        path.LineTo(50f, 50f);
+
+        var stroke = new DrawStroke
+        {
+            Id = Guid.NewGuid(),
+            Path = path,
+            Paint = new StrokePaint { StrokeWidth = 4f },
+            ToolType = ToolType.Pencil,
+            ToolOptions = []
+        };
+
+        var image = new CanvasImage
+        {
+            Id = Guid.NewGuid(),
+            Bounds = new SKRect(20f, 20f, 100f, 100f),
+            ImageBase64String = "BASE64"
+        };
+
+        var actual = Utilities.GetElementsBounds([stroke, image]);
+
+        // stroke bounds inflated: (8, 8, 52, 52)
+        // image bounds: (20, 20, 100, 100)
+        // union of both: (8, 8, 100, 100)
+        actual.Should().Be(new SKRect(8f, 8f, 100f, 100f));
     }
 }

--- a/Scribble/Services/CanvasStateService/CanvasStateService.cs
+++ b/Scribble/Services/CanvasStateService/CanvasStateService.cs
@@ -997,6 +997,77 @@ public class CanvasStateService : ICanvasStateService
                     }
 
                     break;
+                case PasteCanvasElementsEvent ev:
+                {
+                    List<CanvasElement> pastedElements = [];
+                    foreach (var element in ev.CopiedElements)
+                    {
+                        if (element is DrawStroke pastedDrawStroke)
+                        {
+                            pastedElements.Add(new DrawStroke
+                            {
+                                Id = pastedDrawStroke.Id,
+                                Paint = pastedDrawStroke.Paint.Clone(),
+                                ToolOptions = pastedDrawStroke.ToolOptions,
+                                ToolType = pastedDrawStroke.ToolType,
+                                Path = pastedDrawStroke.Path.Clone(),
+                                RawPoints = [..pastedDrawStroke.RawPoints],
+                                LayerIndex = pastedDrawStroke.LayerIndex,
+                                CreatorConnectionId = pastedDrawStroke.CreatorConnectionId
+                            });
+                        }
+                        else if (element is TextStroke pastedTextStroke)
+                        {
+                            pastedElements.Add(new TextStroke
+                            {
+                                Id = pastedTextStroke.Id,
+                                Text = pastedTextStroke.Text,
+                                Position = pastedTextStroke.Position,
+                                Paint = pastedTextStroke.Paint.Clone(),
+                                ToolOptions = pastedTextStroke.ToolOptions,
+                                Path = pastedTextStroke.Path.Clone(),
+                                LayerIndex = pastedTextStroke.LayerIndex,
+                                TransformMatrix = pastedTextStroke.TransformMatrix,
+                                IsBold = pastedTextStroke.IsBold,
+                                IsItalic = pastedTextStroke.IsItalic,
+                                CreatorConnectionId = pastedTextStroke.CreatorConnectionId
+                            });
+                        }
+                        else if (element is CanvasImage pastedCanvasImage)
+                        {
+                            pastedElements.Add(new CanvasImage
+                            {
+                                Id = pastedCanvasImage.Id,
+                                ImageBase64String = pastedCanvasImage.ImageBase64String,
+                                Bounds = pastedCanvasImage.Bounds,
+                                Rotation = pastedCanvasImage.Rotation,
+                                FlipX = pastedCanvasImage.FlipX,
+                                FlipY = pastedCanvasImage.FlipY,
+                                LayerIndex = pastedCanvasImage.LayerIndex,
+                                CreatorConnectionId = pastedCanvasImage.CreatorConnectionId
+                            });
+                        }
+                    }
+
+                    var copiedElementsBounds = Utilities.GetElementsBounds(pastedElements);
+                    var boundsMiddlePos = new SKPoint(copiedElementsBounds.MidX, copiedElementsBounds.MidY);
+                    var delta = ev.Position - boundsMiddlePos;
+                    // Translate all elements such that the middle of the total bound is at the pointer position
+                    MoveElements(pastedElements, delta);
+                    foreach (var copiedElement in pastedElements)
+                    {
+                        if (copiedElement is PaintableStroke stroke)
+                        {
+                            paintableStrokes[stroke.Id] = stroke;
+                        }
+                        else if (copiedElement is CanvasImage image)
+                        {
+                            canvasImages[image.Id] = image;
+                        }
+                    }
+
+                    break;
+                }
             }
         }
 

--- a/Scribble/Services/CanvasStateService/CanvasStateService.cs
+++ b/Scribble/Services/CanvasStateService/CanvasStateService.cs
@@ -612,27 +612,20 @@ public class CanvasStateService : ICanvasStateService
                     if (selectionBounds.ContainsKey(ev.BoundId))
                     {
                         var bound = selectionBounds[ev.BoundId];
+                        List<CanvasElement> elements = [];
                         foreach (var boundTargetId in bound.Targets)
                         {
-                            if (paintableStrokes.ContainsKey(boundTargetId))
+                            if (paintableStrokes.TryGetValue(boundTargetId, out var stroke))
                             {
-                                var stroke = paintableStrokes[boundTargetId];
-                                var matrix = SKMatrix.CreateTranslation(ev.Delta.X, ev.Delta.Y);
-                                stroke.Path.Transform(matrix);
-                                if (stroke is TextStroke movedText)
-                                {
-                                    movedText.TransformMatrix = movedText.TransformMatrix.PostConcat(matrix);
-                                }
+                                elements.Add(stroke);
                             }
-                            else if (canvasImages.ContainsKey(boundTargetId))
+                            else if (canvasImages.TryGetValue(boundTargetId, out var image))
                             {
-                                var image = canvasImages[boundTargetId];
-                                // SKRect is a struct (value-type), so we need to create a new one to modify
-                                var bounds = image.Bounds;
-                                bounds.Offset(ev.Delta);
-                                image.Bounds = bounds;
+                                elements.Add(image);
                             }
                         }
+
+                        MoveElements(elements, ev.Delta);
                     }
 
                     break;
@@ -1184,6 +1177,29 @@ public class CanvasStateService : ICanvasStateService
                 {
                     bound.Targets.Add(image.Id);
                 }
+            }
+        }
+    }
+
+    private static void MoveElements(IEnumerable<CanvasElement> elements, SKPoint delta)
+    {
+        foreach (var canvasElement in elements)
+        {
+            if (canvasElement is PaintableStroke stroke)
+            {
+                var matrix = SKMatrix.CreateTranslation(delta.X, delta.Y);
+                stroke.Path.Transform(matrix);
+                if (stroke is TextStroke movedText)
+                {
+                    movedText.TransformMatrix = movedText.TransformMatrix.PostConcat(matrix);
+                }
+            }
+            else if (canvasElement is CanvasImage image)
+            {
+                // SKRect is a struct (value-type), so we need to create a new one to modify
+                var bounds = image.Bounds;
+                bounds.Offset(delta);
+                image.Bounds = bounds;
             }
         }
     }

--- a/Scribble/Services/CanvasStateService/CanvasStateService.cs
+++ b/Scribble/Services/CanvasStateService/CanvasStateService.cs
@@ -125,6 +125,10 @@ public class CanvasStateService : ICanvasStateService
         {
             _localSelectionBoundIds.Add(ev.BoundId);
         }
+        else if (@event is PasteCanvasElementsEvent pasteEv && isLocalEvent)
+        {
+            _localSelectionBoundIds.Add(pasteEv.SelectionBoundId);
+        }
 
         ProcessEvent(@event, isLocalEvent);
 
@@ -1065,6 +1069,21 @@ public class CanvasStateService : ICanvasStateService
                             canvasImages[image.Id] = image;
                         }
                     }
+
+                    // Automatically select the pasted elements
+                    selectionBounds.Clear();
+                    var pasteSelectionPath = new SKPath();
+                    var selectionRect = Utilities.GetElementsBounds(pastedElements);
+                    pasteSelectionPath.AddRect(selectionRect);
+
+                    var pasteSelectionBound = new SelectionBound
+                    {
+                        Id = ev.SelectionBoundId,
+                        Path = pasteSelectionPath,
+                        CreatorConnectionId = ev.CreatorConnectionId,
+                        Targets = [..pastedElements.Select(e => e.Id)]
+                    };
+                    selectionBounds[ev.SelectionBoundId] = pasteSelectionBound;
 
                     break;
                 }

--- a/Scribble/Utils/Utilities.cs
+++ b/Scribble/Utils/Utilities.cs
@@ -121,6 +121,9 @@ public static class Utilities
         return SKPoint.Distance(point, closest) < tolerance;
     }
 
+    /// <summary>
+    /// Returns the bounds of the elements
+    /// </summary>
     public static SKRect GetElementsBounds(IEnumerable<CanvasElement> elements)
     {
         SKRect totalBounds = SKRect.Empty;

--- a/Scribble/Utils/Utilities.cs
+++ b/Scribble/Utils/Utilities.cs
@@ -1,8 +1,11 @@
 using System;
+using System.Collections.Generic;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Media;
+using Scribble.Shared.Lib.CanvasElements;
+using Scribble.Shared.Lib.CanvasElements.Strokes;
 using SkiaSharp;
 
 namespace Scribble.Utils;
@@ -116,5 +119,40 @@ public static class Utilities
         );
 
         return SKPoint.Distance(point, closest) < tolerance;
+    }
+
+    public static SKRect GetElementsBounds(IEnumerable<CanvasElement> elements)
+    {
+        SKRect totalBounds = SKRect.Empty;
+        foreach (var element in elements)
+        {
+            if (element is PaintableStroke stroke)
+            {
+                SKRect pathBounds = stroke.Path.Bounds;
+                float halfStrokeWidth = stroke.Paint.StrokeWidth / 2;
+                pathBounds.Inflate(halfStrokeWidth, halfStrokeWidth);
+                if (totalBounds.IsEmpty)
+                {
+                    totalBounds = pathBounds;
+                }
+                else
+                {
+                    totalBounds.Union(pathBounds);
+                }
+            }
+            else if (element is CanvasImage canvasImage)
+            {
+                if (totalBounds.IsEmpty)
+                {
+                    totalBounds = canvasImage.Bounds;
+                }
+                else
+                {
+                    totalBounds.Union(canvasImage.Bounds);
+                }
+            }
+        }
+
+        return totalBounds;
     }
 }

--- a/Scribble/ViewModels/CanvasExportViewModel.cs
+++ b/Scribble/ViewModels/CanvasExportViewModel.cs
@@ -161,41 +161,6 @@ public partial class CanvasExportViewModel : ViewModelBase
         await clipboard.SetDataObjectAsync(dataObject);
     }
 
-    private SKRect GetElementsBounds(IEnumerable<CanvasElement> elements)
-    {
-        SKRect totalBounds = SKRect.Empty;
-        foreach (var element in elements)
-        {
-            if (element is PaintableStroke stroke)
-            {
-                SKRect pathBounds = stroke.Path.Bounds;
-                float halfStrokeWidth = stroke.Paint.StrokeWidth / 2;
-                pathBounds.Inflate(halfStrokeWidth, halfStrokeWidth);
-                if (totalBounds.IsEmpty)
-                {
-                    totalBounds = pathBounds;
-                }
-                else
-                {
-                    totalBounds.Union(pathBounds);
-                }
-            }
-            else if (element is CanvasImage canvasImage)
-            {
-                if (totalBounds.IsEmpty)
-                {
-                    totalBounds = canvasImage.Bounds;
-                }
-                else
-                {
-                    totalBounds.Union(canvasImage.Bounds);
-                }
-            }
-        }
-
-        return totalBounds;
-    }
-
     private byte[]? GetImageData(
         List<CanvasElement> elements,
         bool includeBackground,
@@ -209,7 +174,7 @@ public partial class CanvasExportViewModel : ViewModelBase
         }
 
         // Calculate the bounding box of all elements
-        SKRect bounds = GetElementsBounds(elements);
+        SKRect bounds = Utilities.GetElementsBounds(elements);
         // Add padding
         bounds.Inflate(20, 20);
 

--- a/Scribble/ViewModels/MainViewModel.cs
+++ b/Scribble/ViewModels/MainViewModel.cs
@@ -10,7 +10,9 @@ using CommunityToolkit.Mvvm.Input;
 using Scribble.Services.CanvasStateService;
 using Scribble.Services.DialogService;
 using Scribble.Services.MultiUserDrawing;
+using Scribble.Shared.Lib;
 using Scribble.Shared.Lib.CanvasElements;
+using SkiaSharp;
 
 namespace Scribble.ViewModels;
 
@@ -20,11 +22,11 @@ public partial class MainViewModel : ViewModelBase
     public event Action? RequestInvalidateSkiaCanvas;
 
     [ObservableProperty] private List<CanvasElement> _canvasElements = [];
+    private List<CanvasElement> _copiedCanvasElements = [];
 
     private bool CanUndo => CanvasStateService.CanUndo;
     private bool CanRedo => CanvasStateService.CanRedo;
 
-    // Services
     private readonly IDialogService _dialogService;
     private readonly IMultiUserDrawingService _multiUserDrawingService;
     private ICanvasStateService CanvasStateService { get; }
@@ -124,5 +126,20 @@ public partial class MainViewModel : ViewModelBase
         }
 
         CanvasStateService.LoadCanvas([]);
+    }
+
+    [RelayCommand]
+    private void Copy()
+    {
+        _copiedCanvasElements = CanvasStateService.GetSelectedElements()
+            .OfType<ICopyable>()
+            .Select(e => e.Copy())
+            .ToList();
+    }
+
+    [RelayCommand]
+    private void Paste(SKPoint pointerPos)
+    {
+        CanvasStateService.ApplyEvent(new PasteCanvasElementsEvent(Guid.NewGuid(), pointerPos, _copiedCanvasElements));
     }
 }

--- a/Scribble/ViewModels/MainViewModel.cs
+++ b/Scribble/ViewModels/MainViewModel.cs
@@ -140,7 +140,7 @@ public partial class MainViewModel : ViewModelBase
     [RelayCommand]
     private void Paste(SKPoint pointerPos)
     {
-        CanvasStateService.ApplyEvent(new PasteCanvasElementsEvent(Guid.NewGuid(), pointerPos, _copiedCanvasElements));
+        CanvasStateService.ApplyEvent(new PasteCanvasElementsEvent(Guid.NewGuid(), pointerPos, _copiedCanvasElements, Guid.NewGuid()));
 
         // Recreate the copied elements
         _copiedCanvasElements = _copiedCanvasElements

--- a/Scribble/ViewModels/MainViewModel.cs
+++ b/Scribble/ViewModels/MainViewModel.cs
@@ -141,5 +141,11 @@ public partial class MainViewModel : ViewModelBase
     private void Paste(SKPoint pointerPos)
     {
         CanvasStateService.ApplyEvent(new PasteCanvasElementsEvent(Guid.NewGuid(), pointerPos, _copiedCanvasElements));
+
+        // Recreate the copied elements
+        _copiedCanvasElements = _copiedCanvasElements
+            .OfType<ICopyable>()
+            .Select(e => e.Copy())
+            .ToList();
     }
 }

--- a/Scribble/Views/MainView.axaml.cs
+++ b/Scribble/Views/MainView.axaml.cs
@@ -40,6 +40,7 @@ namespace Scribble.Views;
 public partial class MainView : UserControl
 {
     private SKPoint _prevCoord;
+    private SKPoint _lastWorldPointerPos;
     private PointerTool? _activePointerTool;
     private MainViewModel? _viewModel;
     private readonly ICanvasStateService _canvasStateService;
@@ -52,6 +53,7 @@ public partial class MainView : UserControl
     {
         InitializeComponent();
         _prevCoord = SKPoint.Empty;
+        _lastWorldPointerPos = SKPoint.Empty;
         _selection = new Selection();
 
         var moveIconBitmap = Bitmap.DecodeToWidth(AssetLoader.Open(new Uri("avares://Scribble/Assets/move.png")), 36);
@@ -116,6 +118,30 @@ public partial class MainView : UserControl
         {
             Gesture = new KeyGesture(Key.E, KeyModifiers.Control | KeyModifiers.Shift),
             Command = new RelayCommand(() => ExportMenuOption_OnClick(null, null), CanExecuteKeyBinding)
+        });
+
+        RootPanel.KeyBindings.Add(new KeyBinding
+        {
+            Gesture = new KeyGesture(Key.C, KeyModifiers.Control),
+            Command = new RelayCommand(() => viewModel.CopyCommand.Execute(null), CanExecuteKeyBinding)
+        });
+
+        RootPanel.KeyBindings.Add(new KeyBinding
+        {
+            Gesture = new KeyGesture(Key.V, KeyModifiers.Control),
+            Command = new RelayCommand(() =>
+            {
+                var pastePos = _lastWorldPointerPos;
+                if (pastePos.IsEmpty)
+                {
+                    var viewportCenter = new SKPoint(
+                        (float)(MainCanvas.Bounds.Width / 2),
+                        (float)(MainCanvas.Bounds.Height / 2)
+                    );
+                    pastePos = CameraState.ScreenToWorld(viewportCenter);
+                }
+                viewModel.PasteCommand.Execute(pastePos);
+            }, CanExecuteKeyBinding)
         });
     }
 
@@ -464,6 +490,9 @@ public partial class MainView : UserControl
 
     private void MainCanvas_OnPointerMoved(object? sender, PointerEventArgs e)
     {
+        var screenPos = Utilities.ToSkPoint(e.GetPosition(MainCanvas));
+        _lastWorldPointerPos = CameraState.ScreenToWorld(screenPos);
+
         var pointerCoordinates = GetPointerPosition(e);
 
         // Skip if position hasn't changed (tablet pens fire PointerMoved
@@ -488,6 +517,9 @@ public partial class MainView : UserControl
 
     private void MainCanvas_OnPointerPressed(object? sender, PointerPressedEventArgs e)
     {
+        var screenPos = Utilities.ToSkPoint(e.GetPosition(MainCanvas));
+        _lastWorldPointerPos = CameraState.ScreenToWorld(screenPos);
+
         var pointerCoordinates = GetPointerPosition(e);
         if (e.Properties.IsLeftButtonPressed)
         {


### PR DESCRIPTION
This pull request introduces support for copying and pasting canvas elements, along with several related refactorings and utility improvements. The main changes include the addition of a generic `ICopyable` interface for deep copying canvas elements, a new event type and logic for pasting elements, and a utility method for calculating element bounds. Unit tests have also been added to ensure the correctness of these new utilities.

**Copy/Paste Functionality**
* Added the `ICopyable` interface and implemented it for `CanvasImage`, `DrawStroke`, and `TextStroke`, enabling deep copying of canvas elements.
* Introduced the `PasteCanvasElementsEvent` event type and integrated its handling into the event replay logic, including logic to position pasted elements and automatically select them.

**Utilities and Refactoring**
* Added `Utilities.GetElementsBounds`, a utility method to calculate the bounding rectangle of a set of canvas elements, and replaced duplicate bounding logic in `CanvasExportViewModel`.
* Added unit tests for `GetElementsBounds` to verify behavior with empty lists, single strokes, single images, and multiple elements.

**Code Quality and Maintenance**
* Improved the `Clone` method in `StrokePaint` to clear cached paint objects, ensuring correct behavior after cloning.
* Added necessary package references for Avalonia.Skia to support new features.

Closes #107 