### PR TITLE
Refactor event replay and fast path optimizations

### DIFF
--- a/Scribble/Services/CanvasStateService/CanvasStateService.cs
+++ b/Scribble/Services/CanvasStateService/CanvasStateService.cs
@@ -1,14 +1,13 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Avalonia.Skia;
 using Avalonia.Threading;
+using Scribble.Services.CanvasStateService.Context;
+using Scribble.Services.CanvasStateService.Handlers;
 using Scribble.Services.MultiUserDrawing;
 using Scribble.Shared.Lib;
 using Scribble.Shared.Lib.CanvasElements;
 using Scribble.Shared.Lib.CanvasElements.Strokes;
-using Scribble.Tools.PointerTools.ArrowTool;
-using Scribble.Utils;
 using SkiaSharp;
 
 namespace Scribble.Services.CanvasStateService;
@@ -40,6 +39,7 @@ public class CanvasStateService : ICanvasStateService
     public bool CanRedo => _redoStack.Count > 0;
 
     private readonly IMultiUserDrawingService _multiUserDrawingService;
+    private readonly EventReplayDispatcher _dispatcher;
 
     public event Action? CanvasInvalidated;
     public event Action? SelectionInvalidated;
@@ -63,6 +63,20 @@ public class CanvasStateService : ICanvasStateService
         {
             await _multiUserDrawingService.SendCanvasStateToClientAsync(clientId, CanvasEvents);
         };
+
+        _dispatcher = new EventReplayDispatcher(
+            new StrokeReplayHandler(),
+            new EraserReplayHandler(),
+            new SelectionReplayHandler(),
+            new TransformReplayHandler(),
+            new TextReplayHandler(),
+            new PropertyReplayHandler(),
+            new CanvasLifecycleReplayHandler()
+        );
+
+#if DEBUG
+        _dispatcher.ValidateCompleteness(typeof(Event).Assembly);
+#endif
     }
 
     public void Undo()
@@ -169,192 +183,29 @@ public class CanvasStateService : ICanvasStateService
 
     private bool ApplyFastPathOptimization(Event @event)
     {
-        if (@event is PencilStrokeLineToEvent pencilLineToEvent)
+        var fastPathCtx = new FastPathContext
         {
-            if (_strokeLookup.TryGetValue(pencilLineToEvent.StrokeId, out var stroke) && stroke is DrawStroke ds)
-            {
-                ds.RawPoints.Add(new StrokePoint(pencilLineToEvent.Point,
-                    pencilLineToEvent.TimeStamp.Ticks / TimeSpan.TicksPerMillisecond));
-                var newPath = FreehandPathBuilder.Build(ds.RawPoints);
-                ds.Path.Reset();
-                ds.Path.AddPath(newPath);
+            StrokeLookup = _strokeLookup,
+            EraserStrokeLookup = _eraserStrokeLookup,
+            EraserHeadLookup = _eraserHeadLookup,
+            SelectionBoundLookup = _selectionBoundLookup,
+            CanvasImageLookup = _canvasImageLookup,
+            CanvasElements = CanvasElements,
+            LocalSelectionBoundIds = _localSelectionBoundIds,
+            OnCanvasInvalidated = CanvasInvalidated,
+            OnSelectionInvalidated = SelectionInvalidated
+        };
 
-                CanvasInvalidated?.Invoke();
-                return true;
-            }
+        bool applied = _dispatcher.TryFastPath(@event, fastPathCtx);
+
+        // Sync back any selection state changes from the fast-path handler
+        if (applied && fastPathCtx.SelectedElementIds != null)
+        {
+            ActiveSelectionBoundId = fastPathCtx.ActiveSelectionBoundId;
+            SelectedElementIds = fastPathCtx.SelectedElementIds;
         }
 
-        if (@event is LineStrokeLineToEvent lineStrokeEvent)
-        {
-            if (_strokeLookup.TryGetValue(lineStrokeEvent.StrokeId, out var stroke) && stroke is DrawStroke drawStroke)
-            {
-                RebuildLinePath(drawStroke, lineStrokeEvent.EndPoint);
-                CanvasInvalidated?.Invoke();
-                return true;
-            }
-        }
-
-        if (@event is EraseStrokeLineToEvent eraseLineToEvent)
-        {
-            if (_eraserStrokeLookup.TryGetValue(eraseLineToEvent.StrokeId, out var currentEraserStroke))
-            {
-                var start = _eraserHeadLookup[eraseLineToEvent.StrokeId];
-                var end = eraseLineToEvent.Point;
-                var distance = Math.Sqrt(Math.Pow(end.X - start.X, 2) + Math.Pow(end.Y - start.Y, 2));
-
-                var stepSize = 5.0;
-                var steps = (int)Math.Ceiling(distance / stepSize);
-                for (int s = 1; s <= steps; s++)
-                {
-                    var completionPercentage = s / stepSize;
-                    var checkX = start.X + (end.X - start.X) * completionPercentage;
-                    var checkY = start.Y + (end.Y - start.Y) * completionPercentage;
-                    CheckAndErase(new SKPoint((float)checkX, (float)checkY), CanvasElements, currentEraserStroke,
-                        ownerFilter: currentEraserStroke.CreatorConnectionId);
-                }
-
-                currentEraserStroke.Path.LineTo(eraseLineToEvent.Point);
-                _eraserHeadLookup[eraseLineToEvent.StrokeId] = eraseLineToEvent.Point;
-                CanvasInvalidated?.Invoke();
-                return true;
-            }
-        }
-
-        if (@event is IncreaseSelectionBoundEvent increaseSelectionEvent)
-        {
-            if (_selectionBoundLookup.TryGetValue(increaseSelectionEvent.BoundId, out var bound))
-            {
-                var boundOrigin = bound.Path.Points[0];
-                bound.Path.Reset();
-                bound.Path.MoveTo(boundOrigin);
-                bound.Path.LineTo(increaseSelectionEvent.Point);
-
-                var top = Math.Min(boundOrigin.Y, increaseSelectionEvent.Point.Y);
-                var left = Math.Min(boundOrigin.X, increaseSelectionEvent.Point.X);
-                var boundRect = SKRect.Create(new SKPoint(left, top),
-                    Utilities.GetSize(boundOrigin, increaseSelectionEvent.Point));
-                CheckAndSelect(boundRect, bound, CanvasElements,
-                    ownerFilter: bound.CreatorConnectionId);
-
-                var myBound = _selectionBoundLookup.FirstOrDefault(pair => _localSelectionBoundIds.Contains(pair.Key));
-                ActiveSelectionBoundId = myBound.Value != null ? myBound.Key : null;
-                SelectedElementIds = myBound.Value?.Targets.ToList() ?? [];
-                SelectionInvalidated?.Invoke();
-                return true;
-            }
-        }
-
-        if (@event is MoveCanvasElementsEvent moveEvent)
-        {
-            if (_selectionBoundLookup.TryGetValue(moveEvent.BoundId, out var bound))
-            {
-                foreach (var boundTargetId in bound.Targets)
-                {
-                    if (_strokeLookup.TryGetValue(boundTargetId, out var stroke))
-                    {
-                        var matrix = SKMatrix.CreateTranslation(moveEvent.Delta.X, moveEvent.Delta.Y);
-                        stroke.Path.Transform(matrix);
-                        if (stroke is TextStroke textStroke)
-                        {
-                            textStroke.TransformMatrix = textStroke.TransformMatrix.PostConcat(matrix);
-                        }
-                    }
-                    else if (_canvasImageLookup.TryGetValue(boundTargetId, out var image))
-                    {
-                        var bounds = image.Bounds;
-                        bounds.Offset(moveEvent.Delta);
-                        image.Bounds = bounds;
-                    }
-                }
-
-                CanvasInvalidated?.Invoke();
-                SelectionInvalidated?.Invoke();
-                return true;
-            }
-        }
-
-        if (@event is RotateCanvasElementsEvent rotateEvent)
-        {
-            if (_selectionBoundLookup.TryGetValue(rotateEvent.BoundId, out var bound))
-            {
-                foreach (var boundTargetId in bound.Targets)
-                {
-                    if (_strokeLookup.TryGetValue(boundTargetId, out var stroke))
-                    {
-                        var matrix = SKMatrix.CreateRotation(rotateEvent.DegreesRad, rotateEvent.Center.X,
-                            rotateEvent.Center.Y);
-                        stroke.Path.Transform(matrix);
-                        if (stroke is TextStroke textStroke)
-                        {
-                            textStroke.TransformMatrix = textStroke.TransformMatrix.PostConcat(matrix);
-                        }
-                    }
-                    else if (_canvasImageLookup.TryGetValue(boundTargetId, out var image))
-                    {
-                        image.Rotation += rotateEvent.DegreesRad;
-                        var imgCenter = new SKPoint(image.Bounds.MidX, image.Bounds.MidY);
-                        var rotated = SKMatrix
-                            .CreateRotation(rotateEvent.DegreesRad, rotateEvent.Center.X, rotateEvent.Center.Y)
-                            .MapPoint(imgCenter);
-                        var bounds = image.Bounds;
-                        bounds.Offset(rotated.X - imgCenter.X, rotated.Y - imgCenter.Y);
-                        image.Bounds = bounds;
-                    }
-                }
-
-                CanvasInvalidated?.Invoke();
-                SelectionInvalidated?.Invoke();
-                return true;
-            }
-        }
-
-        if (@event is ScaleCanvasElementsEvent scaleEvent)
-        {
-            if (_selectionBoundLookup.TryGetValue(scaleEvent.BoundId, out var bound))
-            {
-                foreach (var boundTargetId in bound.Targets)
-                {
-                    if (_strokeLookup.TryGetValue(boundTargetId, out var stroke))
-                    {
-                        var matrix = SKMatrix.CreateScale(scaleEvent.Scale.X, scaleEvent.Scale.Y, scaleEvent.Center.X,
-                            scaleEvent.Center.Y);
-                        stroke.Path.Transform(matrix);
-                        if (stroke is TextStroke textStroke)
-                        {
-                            textStroke.TransformMatrix = textStroke.TransformMatrix.PostConcat(matrix);
-                        }
-                    }
-                    else if (_canvasImageLookup.TryGetValue(boundTargetId, out var image))
-                    {
-                        var scaleMatrix = SKMatrix.CreateScale(scaleEvent.Scale.X, scaleEvent.Scale.Y,
-                            scaleEvent.Center.X, scaleEvent.Center.Y);
-                        var topLeft = scaleMatrix.MapPoint(new SKPoint(image.Bounds.Left, image.Bounds.Top));
-                        var bottomRight =
-                            scaleMatrix.MapPoint(new SKPoint(image.Bounds.Right, image.Bounds.Bottom));
-
-                        if (topLeft.X > bottomRight.X)
-                        {
-                            (topLeft.X, bottomRight.X) = (bottomRight.X, topLeft.X);
-                            image.FlipX = !image.FlipX;
-                        }
-
-                        if (topLeft.Y > bottomRight.Y)
-                        {
-                            (topLeft.Y, bottomRight.Y) = (bottomRight.Y, topLeft.Y);
-                            image.FlipY = !image.FlipY;
-                        }
-
-                        image.Bounds = new SKRect(topLeft.X, topLeft.Y, bottomRight.X, bottomRight.Y);
-                    }
-                }
-
-                CanvasInvalidated?.Invoke();
-                SelectionInvalidated?.Invoke();
-                return true;
-            }
-        }
-
-        return false;
+        return applied;
     }
 
     private void ProcessEvent(Event @event, bool isLocalEvent = false)
@@ -407,6 +258,7 @@ public class CanvasStateService : ICanvasStateService
     /// <returns></returns>
     private List<Guid> ReplayEvents()
     {
+        // Determine which action IDs are hidden by Undo/Redo events
         var hiddenActionIds = new HashSet<Guid>();
         foreach (var canvasEvent in CanvasEvents)
         {
@@ -420,678 +272,26 @@ public class CanvasStateService : ICanvasStateService
             }
         }
 
-        var paintableStrokes = new Dictionary<Guid, PaintableStroke>();
-        var eraserStrokes = new Dictionary<Guid, EraserStroke>();
-        var eraserHeads = new Dictionary<Guid, SKPoint>();
-        var selectionBounds = new Dictionary<Guid, SelectionBound>();
-        var staleActionIds = new List<Guid>();
-        var canvasImages = new Dictionary<Guid, CanvasImage>();
-
-        var currentMaxLayerIndex = 0;
-        var currentMinLayerIndex = 0;
+        // Replay all visible events through registered handlers
+        var ctx = new ReplayContext();
         foreach (var canvasEvent in CanvasEvents.Where(canvasEvent => !hiddenActionIds.Contains(canvasEvent.ActionId)))
         {
-            switch (canvasEvent)
-            {
-                case StartStrokeEvent ev:
-                    var newLinePath = new SKPath();
-                    newLinePath.MoveTo(ev.StartPoint);
-                    paintableStrokes[ev.StrokeId] = new DrawStroke
-                    {
-                        Id = ev.StrokeId,
-                        Paint = ev.StrokePaint.Clone(),
-                        Path = newLinePath,
-                        RawPoints = [new StrokePoint(ev.StartPoint, ev.TimeStamp.Ticks / TimeSpan.TicksPerMillisecond)],
-                        ToolType = ev.ToolType,
-                        ToolOptions = ev.ToolOptions,
-                        CreatorConnectionId = ev.CreatorConnectionId,
-                        LayerIndex = currentMaxLayerIndex
-                    };
-                    break;
-                case StartEraseStrokeEvent ev:
-                    var eraserPath = new SKPath();
-                    eraserPath.MoveTo(ev.StartPoint);
-                    var newEraserStroke = new EraserStroke
-                    {
-                        Path = eraserPath,
-                        CreatorConnectionId = ev.CreatorConnectionId
-                    };
-
-                    // Keep track of the eraser heads for linear interpolation
-                    eraserHeads[ev.StrokeId] = ev.StartPoint;
-
-                    // Find all targets for erasing
-                    CheckAndErase(ev.StartPoint, [..paintableStrokes.Values, ..canvasImages.Values], newEraserStroke,
-                        ownerFilter: ev.CreatorConnectionId);
-
-                    eraserStrokes[ev.StrokeId] = newEraserStroke;
-                    break;
-                case EraseStrokeLineToEvent ev:
-                    if (eraserStrokes.ContainsKey(ev.StrokeId))
-                    {
-                        var currentEraserStroke = eraserStrokes[ev.StrokeId];
-                        // Use interpolation to find all targets for erasing
-                        var start = eraserHeads[ev.StrokeId];
-                        var end = ev.Point;
-                        var distance = Math.Sqrt(Math.Pow(end.X - start.X, 2) + Math.Pow(end.Y - start.Y, 2));
-
-                        var stepSize = 5.0;
-                        var steps = (int)Math.Ceiling(distance / stepSize);
-                        for (int s = 1; s <= steps; s++)
-                        {
-                            var completionPercentage = s / stepSize;
-                            var checkX = start.X + (end.X - start.X) * completionPercentage;
-                            var checkY = start.Y + (end.Y - start.Y) * completionPercentage;
-                            CheckAndErase(new SKPoint((float)checkX, (float)checkY),
-                                [..paintableStrokes.Values, ..canvasImages.Values],
-                                currentEraserStroke,
-                                ownerFilter: currentEraserStroke.CreatorConnectionId);
-                        }
-
-                        currentEraserStroke.Path.LineTo(ev.Point);
-                        eraserHeads[ev.StrokeId] = ev.Point;
-                    }
-
-                    break;
-                case TriggerEraseEvent ev:
-                    if (eraserStrokes.ContainsKey(ev.StrokeId))
-                    {
-                        // Erase all targets
-                        foreach (var targetId in eraserStrokes[ev.StrokeId].Targets)
-                        {
-                            paintableStrokes.Remove(targetId);
-                            canvasImages.Remove(targetId);
-                        }
-
-                        if (eraserStrokes[ev.StrokeId].Targets.Count == 0)
-                        {
-                            staleActionIds.Add(ev.ActionId);
-                        }
-                    }
-
-                    break;
-                case PencilStrokeLineToEvent ev:
-                    if (paintableStrokes.TryGetValue(ev.StrokeId, out var pStroke) && pStroke is DrawStroke dsPencil)
-                    {
-                        dsPencil.RawPoints.Add(new StrokePoint(ev.Point,
-                            ev.TimeStamp.Ticks / TimeSpan.TicksPerMillisecond));
-                        var newPath = FreehandPathBuilder.Build(dsPencil.RawPoints);
-                        dsPencil.Path.Reset();
-                        dsPencil.Path.AddPath(newPath);
-                    }
-
-                    break;
-                case LineStrokeLineToEvent ev:
-                    if (paintableStrokes.TryGetValue(ev.StrokeId, out var paintableStroke) &&
-                        paintableStroke is DrawStroke ds)
-                    {
-                        RebuildLinePath(ds, ev.EndPoint);
-                    }
-
-                    break;
-                case AddTextEvent ev:
-                    var textPath = new SKPath();
-                    textPath.MoveTo(ev.Position);
-                    textPath.AddPath(
-                        TextPathBuilder.Build(ev.Text, ev.Position.X, ev.Position.Y, ev.Paint.TextSize,
-                            StrokePaint.DefaultTypeFace));
-                    paintableStrokes[ev.StrokeId] = new TextStroke
-                    {
-                        Id = ev.StrokeId,
-                        Paint = ev.Paint.Clone(),
-                        Path = textPath,
-                        ToolOptions = ev.ToolOptions,
-                        Text = ev.Text,
-                        Position = ev.Position,
-                        CreatorConnectionId = ev.CreatorConnectionId,
-                        LayerIndex = currentMaxLayerIndex
-                    };
-                    break;
-                case UpdateTextEvent ev:
-                    if (paintableStrokes.TryGetValue(ev.TextStrokeId, out var existingStroke) &&
-                        existingStroke is TextStroke textStroke)
-                    {
-                        textStroke.Text = ev.NewText;
-                        var updateTextTypeface = SKTypeface.FromFamilyName(
-                            StrokePaint.DefaultTypeFace.FamilyName, textStroke.SkFontStyle);
-                        var newTextPath = new SKPath();
-                        newTextPath.MoveTo(textStroke.Position);
-                        newTextPath.AddPath(
-                            TextPathBuilder.Build(ev.NewText, textStroke.Position.X, textStroke.Position.Y,
-                                textStroke.Paint.TextSize, updateTextTypeface));
-
-                        newTextPath.Transform(textStroke.TransformMatrix);
-
-                        textStroke.Path.Reset();
-                        textStroke.Path.AddPath(newTextPath);
-                    }
-
-                    break;
-                case CreateSelectionBoundEvent ev:
-                    var selectionPath = new SKPath();
-                    selectionPath.MoveTo(ev.StartPoint);
-
-                    selectionBounds.Clear();
-
-                    var selectionBound = new SelectionBound
-                    {
-                        Id = ev.BoundId,
-                        Path = selectionPath,
-                        CreatorConnectionId = ev.CreatorConnectionId
-                    };
-                    selectionBounds[ev.BoundId] = selectionBound;
-                    break;
-                case IncreaseSelectionBoundEvent ev:
-                    if (selectionBounds.ContainsKey(ev.BoundId))
-                    {
-                        var bound = selectionBounds[ev.BoundId];
-                        var boundOrigin = bound.Path.Points[0];
-                        bound.Path.Reset();
-                        bound.Path.MoveTo(boundOrigin);
-                        bound.Path.LineTo(ev.Point);
-
-                        // Check for strokes that are within this bound
-                        var top = Math.Min(boundOrigin.Y, ev.Point.Y);
-                        var left = Math.Min(boundOrigin.X, ev.Point.X);
-                        var boundRect = SKRect.Create(new SKPoint(left, top), Utilities.GetSize(boundOrigin, ev.Point));
-                        CheckAndSelect(boundRect, bound, [..paintableStrokes.Values, ..canvasImages.Values],
-                            ownerFilter: bound.CreatorConnectionId);
-                    }
-
-                    break;
-                case EndSelectionEvent ev:
-                    if (selectionBounds.ContainsKey(ev.BoundId))
-                    {
-                        if (selectionBounds[ev.BoundId].Targets.Count == 0)
-                        {
-                            staleActionIds.Add(ev.ActionId);
-                        }
-                    }
-
-                    break;
-                case ClearSelectionEvent:
-                    selectionBounds.Clear();
-                    break;
-                case MoveCanvasElementsEvent ev:
-                    if (selectionBounds.ContainsKey(ev.BoundId))
-                    {
-                        var bound = selectionBounds[ev.BoundId];
-                        List<CanvasElement> elements = [];
-                        foreach (var boundTargetId in bound.Targets)
-                        {
-                            if (paintableStrokes.TryGetValue(boundTargetId, out var stroke))
-                            {
-                                elements.Add(stroke);
-                            }
-                            else if (canvasImages.TryGetValue(boundTargetId, out var image))
-                            {
-                                elements.Add(image);
-                            }
-                        }
-
-                        MoveElements(elements, ev.Delta);
-                    }
-
-                    break;
-                case RotateCanvasElementsEvent ev:
-                    if (selectionBounds.ContainsKey(ev.BoundId))
-                    {
-                        var bound = selectionBounds[ev.BoundId];
-                        foreach (var boundTargetId in bound.Targets)
-                        {
-                            if (paintableStrokes.ContainsKey(boundTargetId))
-                            {
-                                var stroke = paintableStrokes[boundTargetId];
-                                var matrix = SKMatrix.CreateRotation(ev.DegreesRad, ev.Center.X, ev.Center.Y);
-                                stroke.Path.Transform(matrix);
-                                if (stroke is TextStroke rotatedText)
-                                {
-                                    rotatedText.TransformMatrix = rotatedText.TransformMatrix.PostConcat(matrix);
-                                }
-                            }
-                            else if (canvasImages.ContainsKey(boundTargetId))
-                            {
-                                var image = canvasImages[boundTargetId];
-                                image.Rotation += ev.DegreesRad;
-
-                                // Rotate the bounds center around the rotation pivot
-                                var imgCenter = new SKPoint(image.Bounds.MidX, image.Bounds.MidY);
-                                var rotated = SKMatrix.CreateRotation(ev.DegreesRad, ev.Center.X, ev.Center.Y)
-                                    .MapPoint(imgCenter);
-                                var bounds = image.Bounds;
-                                bounds.Offset(rotated.X - imgCenter.X, rotated.Y - imgCenter.Y);
-                                image.Bounds = bounds;
-                            }
-                        }
-                    }
-
-                    break;
-                case ScaleCanvasElementsEvent ev:
-                    if (selectionBounds.ContainsKey(ev.BoundId))
-                    {
-                        var bound = selectionBounds[ev.BoundId];
-                        foreach (var boundTargetId in bound.Targets)
-                        {
-                            if (paintableStrokes.ContainsKey(boundTargetId))
-                            {
-                                var stroke = paintableStrokes[boundTargetId];
-                                var matrix = SKMatrix.CreateScale(ev.Scale.X, ev.Scale.Y, ev.Center.X, ev.Center.Y);
-                                stroke.Path.Transform(matrix);
-                                if (stroke is TextStroke scaledText)
-                                {
-                                    scaledText.TransformMatrix = scaledText.TransformMatrix.PostConcat(matrix);
-                                }
-                            }
-                            else if (canvasImages.ContainsKey(boundTargetId))
-                            {
-                                var image = canvasImages[boundTargetId];
-                                var scaleMatrix =
-                                    SKMatrix.CreateScale(ev.Scale.X, ev.Scale.Y, ev.Center.X, ev.Center.Y);
-                                var topLeft = scaleMatrix.MapPoint(new SKPoint(image.Bounds.Left, image.Bounds.Top));
-                                var bottomRight =
-                                    scaleMatrix.MapPoint(new SKPoint(image.Bounds.Right, image.Bounds.Bottom));
-
-                                // If the x-axis becomes inverted, swap the x coordinates so that the bound's width stays positive
-                                // Then flip the image horizontally
-                                if (topLeft.X > bottomRight.X)
-                                {
-                                    (topLeft.X, bottomRight.X) = (bottomRight.X, topLeft.X);
-                                    image.FlipX = !image.FlipX;
-                                }
-
-                                // If the y-axis becomes inverted, swap the y coordinates so that the bound's height stays positive
-                                // Then flip the image vertically
-                                if (topLeft.Y > bottomRight.Y)
-                                {
-                                    (topLeft.Y, bottomRight.Y) = (bottomRight.Y, topLeft.Y);
-                                    image.FlipY = !image.FlipY;
-                                }
-
-                                image.Bounds = new SKRect(topLeft.X, topLeft.Y, bottomRight.X, bottomRight.Y);
-                            }
-                        }
-                    }
-
-                    break;
-                case LoadCanvasEvent ev:
-                    paintableStrokes.Clear();
-                    canvasImages.Clear();
-                    eraserStrokes.Clear();
-                    eraserHeads.Clear();
-                    selectionBounds.Clear();
-
-                    foreach (var element in ev.CanvasElements)
-                    {
-                        if (element is DrawStroke drawStroke)
-                        {
-                            paintableStrokes[drawStroke.Id] = new DrawStroke
-                            {
-                                Id = drawStroke.Id,
-                                Paint = drawStroke.Paint.Clone(),
-                                ToolOptions = drawStroke.ToolOptions,
-                                ToolType = drawStroke.ToolType,
-                                Path = drawStroke.Path.Clone(),
-                                RawPoints = [..drawStroke.RawPoints],
-                                LayerIndex = drawStroke.LayerIndex,
-                                CreatorConnectionId = drawStroke.CreatorConnectionId
-                            };
-                            currentMaxLayerIndex =
-                                Math.Max(currentMaxLayerIndex, paintableStrokes[drawStroke.Id].LayerIndex);
-                        }
-                        else if (element is TextStroke loadedText)
-                        {
-                            paintableStrokes[loadedText.Id] = new TextStroke
-                            {
-                                Id = loadedText.Id,
-                                Text = loadedText.Text,
-                                Position = loadedText.Position,
-                                Paint = loadedText.Paint.Clone(),
-                                ToolOptions = loadedText.ToolOptions,
-                                Path = loadedText.Path.Clone(),
-                                LayerIndex = loadedText.LayerIndex,
-                                TransformMatrix = loadedText.TransformMatrix,
-                                IsBold = loadedText.IsBold,
-                                IsItalic = loadedText.IsItalic,
-                                CreatorConnectionId = loadedText.CreatorConnectionId
-                            };
-                            currentMaxLayerIndex =
-                                Math.Max(currentMaxLayerIndex, paintableStrokes[loadedText.Id].LayerIndex);
-                        }
-                        else if (element is CanvasImage canvasImage)
-                        {
-                            canvasImages[canvasImage.Id] = new CanvasImage
-                            {
-                                Id = canvasImage.Id,
-                                ImageBase64String = canvasImage.ImageBase64String,
-                                Bounds = canvasImage.Bounds,
-                                Rotation = canvasImage.Rotation,
-                                FlipX = canvasImage.FlipX,
-                                FlipY = canvasImage.FlipY,
-                                LayerIndex = canvasImage.LayerIndex,
-                                CreatorConnectionId = canvasImage.CreatorConnectionId
-                            };
-                            currentMaxLayerIndex =
-                                Math.Max(currentMaxLayerIndex, canvasImages[canvasImage.Id].LayerIndex);
-                        }
-                    }
-
-                    break;
-                case SetElementLayerEvent ev:
-                    foreach (var elementId in ev.TargetElementIds)
-                    {
-                        if (paintableStrokes.TryGetValue(elementId, out var stroke))
-                        {
-                            stroke.LayerIndex = ev.NewLayerIndex;
-                            currentMaxLayerIndex = Math.Max(currentMaxLayerIndex, stroke.LayerIndex);
-                        }
-                        else if (canvasImages.TryGetValue(elementId, out var image))
-                        {
-                            image.LayerIndex = ev.NewLayerIndex;
-                            currentMaxLayerIndex = Math.Max(currentMaxLayerIndex, image.LayerIndex);
-                        }
-                    }
-
-                    currentMaxLayerIndex = Math.Max(currentMaxLayerIndex, ev.NewLayerIndex);
-                    currentMinLayerIndex = Math.Min(currentMinLayerIndex, ev.NewLayerIndex);
-                    break;
-                case NudgeElementLayerEvent ev:
-                    int newMinLayerIndex = 0;
-                    int newMaxLayerIndex = 0;
-                    foreach (var elementId in ev.TargetElementIds)
-                    {
-                        if (paintableStrokes.TryGetValue(elementId, out var stroke))
-                        {
-                            var newLayer = stroke.LayerIndex + ev.Offset;
-
-                            stroke.LayerIndex = newLayer;
-                            newMaxLayerIndex = Math.Max(newMaxLayerIndex, newLayer);
-                            newMinLayerIndex = Math.Min(newMinLayerIndex, newLayer);
-                        }
-                        else if (canvasImages.TryGetValue(elementId, out var image))
-                        {
-                            var newLayer = image.LayerIndex + ev.Offset;
-
-                            image.LayerIndex = newLayer;
-                            newMaxLayerIndex = Math.Max(newMaxLayerIndex, newLayer);
-                            newMinLayerIndex = Math.Min(newMinLayerIndex, newLayer);
-                        }
-                    }
-
-                    currentMinLayerIndex = Math.Min(currentMinLayerIndex, newMinLayerIndex);
-                    currentMaxLayerIndex = Math.Max(currentMaxLayerIndex, newMaxLayerIndex);
-
-                    break;
-                case UpdateStrokeColorEvent ev:
-                    foreach (var strokeId in ev.StrokeIds)
-                    {
-                        paintableStrokes[strokeId].Paint.Color = ev.NewColor;
-                    }
-
-                    break;
-                case UpdateStrokeThicknessEvent ev:
-                    foreach (var strokeId in ev.StrokeIds)
-                    {
-                        paintableStrokes[strokeId].Paint.StrokeWidth = ev.NewThickness;
-                    }
-
-                    break;
-                case UpdateStrokeStyleEvent ev:
-                    foreach (var strokeId in ev.StrokeIds)
-                    {
-                        paintableStrokes[strokeId].Paint.DashIntervals = ev.NewDashIntervals;
-                    }
-
-                    break;
-                case UpdateStrokeFillColorEvent ev:
-                    foreach (var strokeId in ev.StrokeIds)
-                    {
-                        paintableStrokes[strokeId].Paint.FillColor = ev.NewFillColor;
-                    }
-
-                    break;
-                case UpdateStrokeEdgeTypeEvent ev:
-                    foreach (var strokeId in ev.StrokeIds)
-                    {
-                        var stroke = paintableStrokes[strokeId];
-                        stroke.Paint.StrokeJoin = ev.NewStrokeJoin;
-                        // Recreate the stroke paths, preserving any rotation
-
-                        // Detect a rotation angle if any from the first edge of the rect/roundrect sub-path
-                        var points = stroke.Path.Points;
-                        var rotationAngle = (float)Math.Atan2(
-                            points[2].Y - points[1].Y,
-                            points[2].X - points[1].X);
-
-                        // Un-rotate around the shape's center to recover axis-aligned dimensions
-                        var center = new SKPoint(
-                            stroke.Path.TightBounds.MidX,
-                            stroke.Path.TightBounds.MidY);
-
-                        using var unrotatedPath = new SKPath(stroke.Path);
-                        if (Math.Abs(rotationAngle) > 0.001f)
-                        {
-                            unrotatedPath.Transform(
-                                SKMatrix.CreateRotation(-rotationAngle, center.X, center.Y));
-                        }
-
-                        var bounds = unrotatedPath.Bounds;
-                        var lineStartPoint = unrotatedPath.Points[0];
-                        var lineEndPoint = new SKPoint(
-                            bounds.Left + bounds.Right - lineStartPoint.X,
-                            bounds.Top + bounds.Bottom - lineStartPoint.Y
-                        );
-
-                        // Rebuild the path with the new edge type
-                        stroke.Path.Reset();
-                        stroke.Path.MoveTo(lineStartPoint);
-                        var left = Math.Min(lineStartPoint.X, lineEndPoint.X);
-                        var top = Math.Min(lineStartPoint.Y, lineEndPoint.Y);
-                        var rect = SKRect.Create(new SKPoint(left, top),
-                            Utilities.GetSize(lineStartPoint, lineEndPoint));
-                        if (stroke.Paint.StrokeJoin == SKStrokeJoin.Miter)
-                        {
-                            stroke.Path.AddRect(rect);
-                        }
-                        else
-                        {
-                            stroke.Path.AddRoundRect(rect, 24f, 24f);
-                        }
-
-                        // Re-apply the rotation
-                        if (Math.Abs(rotationAngle) > 0.001f)
-                        {
-                            stroke.Path.Transform(
-                                SKMatrix.CreateRotation(rotationAngle, center.X, center.Y));
-                        }
-                    }
-
-                    break;
-                case UpdateFontSizeEvent ev:
-                    foreach (var strokeId in ev.StrokeIds)
-                    {
-                        if (paintableStrokes.TryGetValue(strokeId, out var stroke) && stroke is TextStroke ts)
-                        {
-                            var fontSizeTypeface = SKTypeface.FromFamilyName(
-                                StrokePaint.DefaultTypeFace.FamilyName, ts.SkFontStyle);
-                            var noTransformTextPath = new SKPath();
-                            noTransformTextPath.MoveTo(ts.Position);
-                            noTransformTextPath.AddPath(
-                                TextPathBuilder.Build(ts.Text, ts.Position.X, ts.Position.Y, ev.FontSize,
-                                    fontSizeTypeface));
-                            noTransformTextPath.Transform(ts.TransformMatrix);
-                            ts.Path.Reset();
-                            ts.Path.AddPath(noTransformTextPath);
-                        }
-                    }
-
-                    break;
-                case AddImageEvent ev:
-                    var imageBounds = SKRect.Create(ev.Position, ev.Size);
-                    canvasImages[ev.ImageId] = new CanvasImage
-                    {
-                        Id = ev.ImageId,
-                        ImageBase64String = ev.ImageBase64String,
-                        Bounds = imageBounds,
-                        CreatorConnectionId = ev.CreatorConnectionId,
-                        LayerIndex = currentMaxLayerIndex
-                    };
-                    break;
-                case UpdateFontCasingEvent ev:
-                    foreach (var strokeId in ev.TextStrokeIds)
-                    {
-                        if (paintableStrokes.TryGetValue(strokeId, out var stroke) && stroke is TextStroke ts)
-                        {
-                            ts.Text = ev.NewCasing == FontCasing.UpperCase ? ts.Text.ToUpper() : ts.Text.ToLower();
-
-                            // Recreate stroke paths
-                            var casingTypeface = SKTypeface.FromFamilyName(
-                                StrokePaint.DefaultTypeFace.FamilyName, ts.SkFontStyle);
-                            var newTextPath = new SKPath();
-                            newTextPath.MoveTo(ts.Position);
-                            newTextPath.AddPath(
-                                TextPathBuilder.Build(ts.Text, ts.Position.X, ts.Position.Y,
-                                    ts.Paint.TextSize, casingTypeface));
-
-                            newTextPath.Transform(ts.TransformMatrix);
-
-                            ts.Path.Reset();
-                            ts.Path.AddPath(newTextPath);
-                        }
-                    }
-
-                    break;
-                case UpdateFontStyleEvent ev:
-                    foreach (var strokeId in ev.TextStrokeIds)
-                    {
-                        if (paintableStrokes.TryGetValue(strokeId, out var stroke) && stroke is TextStroke ts)
-                        {
-                            if (ev.NewStyle == FontStyle.Normal)
-                            {
-                                // resets both bold and italic
-                                ts.IsBold = false;
-                                ts.IsItalic = false;
-                            }
-                            else if (ev.NewStyle == FontStyle.Bold)
-                            {
-                                // Toggle bold
-                                ts.IsBold = !ts.IsBold;
-                            }
-                            else if (ev.NewStyle == FontStyle.Italic)
-                            {
-                                // Toggle italic
-                                ts.IsItalic = !ts.IsItalic;
-                            }
-
-                            // Derive typeface from the updated bold/italic state
-                            var newTypeFace = SKTypeface.FromFamilyName(
-                                StrokePaint.DefaultTypeFace.FamilyName, ts.SkFontStyle);
-
-                            // Recreate stroke paths
-                            var newTextPath = new SKPath();
-                            newTextPath.MoveTo(ts.Position);
-                            newTextPath.AddPath(
-                                TextPathBuilder.Build(ts.Text, ts.Position.X, ts.Position.Y,
-                                    ts.Paint.TextSize, newTypeFace));
-
-                            newTextPath.Transform(ts.TransformMatrix);
-
-                            ts.Path.Reset();
-                            ts.Path.AddPath(newTextPath);
-                        }
-                    }
-
-                    break;
-                case PasteCanvasElementsEvent ev:
-                {
-                    List<CanvasElement> pastedElements = [];
-                    foreach (var element in ev.CopiedElements)
-                    {
-                        if (element is DrawStroke pastedDrawStroke)
-                        {
-                            pastedElements.Add(new DrawStroke
-                            {
-                                Id = pastedDrawStroke.Id,
-                                Paint = pastedDrawStroke.Paint.Clone(),
-                                ToolOptions = pastedDrawStroke.ToolOptions,
-                                ToolType = pastedDrawStroke.ToolType,
-                                Path = pastedDrawStroke.Path.Clone(),
-                                RawPoints = [..pastedDrawStroke.RawPoints],
-                                LayerIndex = pastedDrawStroke.LayerIndex,
-                                CreatorConnectionId = pastedDrawStroke.CreatorConnectionId
-                            });
-                        }
-                        else if (element is TextStroke pastedTextStroke)
-                        {
-                            pastedElements.Add(new TextStroke
-                            {
-                                Id = pastedTextStroke.Id,
-                                Text = pastedTextStroke.Text,
-                                Position = pastedTextStroke.Position,
-                                Paint = pastedTextStroke.Paint.Clone(),
-                                ToolOptions = pastedTextStroke.ToolOptions,
-                                Path = pastedTextStroke.Path.Clone(),
-                                LayerIndex = pastedTextStroke.LayerIndex,
-                                TransformMatrix = pastedTextStroke.TransformMatrix,
-                                IsBold = pastedTextStroke.IsBold,
-                                IsItalic = pastedTextStroke.IsItalic,
-                                CreatorConnectionId = pastedTextStroke.CreatorConnectionId
-                            });
-                        }
-                        else if (element is CanvasImage pastedCanvasImage)
-                        {
-                            pastedElements.Add(new CanvasImage
-                            {
-                                Id = pastedCanvasImage.Id,
-                                ImageBase64String = pastedCanvasImage.ImageBase64String,
-                                Bounds = pastedCanvasImage.Bounds,
-                                Rotation = pastedCanvasImage.Rotation,
-                                FlipX = pastedCanvasImage.FlipX,
-                                FlipY = pastedCanvasImage.FlipY,
-                                LayerIndex = pastedCanvasImage.LayerIndex,
-                                CreatorConnectionId = pastedCanvasImage.CreatorConnectionId
-                            });
-                        }
-                    }
-
-                    var copiedElementsBounds = Utilities.GetElementsBounds(pastedElements);
-                    var boundsMiddlePos = new SKPoint(copiedElementsBounds.MidX, copiedElementsBounds.MidY);
-                    var delta = ev.Position - boundsMiddlePos;
-                    // Translate all elements such that the middle of the total bound is at the pointer position
-                    MoveElements(pastedElements, delta);
-                    foreach (var copiedElement in pastedElements)
-                    {
-                        if (copiedElement is PaintableStroke stroke)
-                        {
-                            paintableStrokes[stroke.Id] = stroke;
-                        }
-                        else if (copiedElement is CanvasImage image)
-                        {
-                            canvasImages[image.Id] = image;
-                        }
-                    }
-
-                    // Automatically select the pasted elements
-                    selectionBounds.Clear();
-                    var pasteSelectionPath = new SKPath();
-                    var selectionRect = Utilities.GetElementsBounds(pastedElements);
-                    pasteSelectionPath.AddRect(selectionRect);
-
-                    var pasteSelectionBound = new SelectionBound
-                    {
-                        Id = ev.SelectionBoundId,
-                        Path = pasteSelectionPath,
-                        CreatorConnectionId = ev.CreatorConnectionId,
-                        Targets = [..pastedElements.Select(e => e.Id)]
-                    };
-                    selectionBounds[ev.SelectionBoundId] = pasteSelectionBound;
-
-                    break;
-                }
-            }
+            _dispatcher.Dispatch(canvasEvent, ctx);
         }
 
+        // Normalize layer indices and update service state
+        NormalizeLayersAndUpdateState(ctx);
+        return ctx.StaleActionIds;
+    }
+
+    /// <summary>
+    /// Normalizes layer indices to be contiguous (0..N-1) while preserving relative ordering,
+    /// then updates all service-level state from the replay context.
+    /// </summary>
+    private void NormalizeLayersAndUpdateState(ReplayContext ctx)
+    {
         // Normalize layer indices to be contiguous (0..N-1) while preserving relative ordering.
-        List<CanvasElement> elementsWithLayers = [..paintableStrokes.Values.ToList(), ..canvasImages.Values.ToList()];
+        List<CanvasElement> elementsWithLayers = [..ctx.PaintableStrokes.Values.ToList(), ..ctx.CanvasImages.Values.ToList()];
 
         if (elementsWithLayers.Count > 0)
         {
@@ -1114,183 +314,18 @@ public class CanvasStateService : ICanvasStateService
         }
 
         CanvasElements = elementsWithLayers;
-        _strokeLookup = paintableStrokes;
-        _eraserStrokeLookup = eraserStrokes;
-        _eraserHeadLookup = eraserHeads;
-        _selectionBoundLookup = selectionBounds;
-        _canvasImageLookup = canvasImages;
+        _strokeLookup = ctx.PaintableStrokes;
+        _eraserStrokeLookup = ctx.EraserStrokes;
+        _eraserHeadLookup = ctx.EraserHeads;
+        _selectionBoundLookup = ctx.SelectionBounds;
+        _canvasImageLookup = ctx.CanvasImages;
 
         // Show the selection only on the client that is doing the selection
-        var mySelectionBound = selectionBounds.FirstOrDefault(pair => _localSelectionBoundIds.Contains(pair.Key));
+        var mySelectionBound = ctx.SelectionBounds.FirstOrDefault(pair => _localSelectionBoundIds.Contains(pair.Key));
         ActiveSelectionBoundId = mySelectionBound.Value != null ? mySelectionBound.Key : null;
         SelectedElementIds = mySelectionBound.Value?.Targets.ToList() ?? [];
 
         CanvasInvalidated?.Invoke();
         SelectionInvalidated?.Invoke();
-        return staleActionIds;
-    }
-
-    /// <summary>
-    /// Builds the path for strokes: Rectangles, Ellipses, Lines, and Arrows
-    /// </summary>
-    /// <param name="stroke">The DrawStroke object</param>
-    /// <param name="endPoint">The line endpoint</param>
-    private static void RebuildLinePath(DrawStroke stroke, SKPoint endPoint)
-    {
-        var lineStartPoint = stroke.Path.Points[0];
-        stroke.Path.Reset();
-
-        if (stroke.ToolType == ToolType.Rectangle)
-        {
-            stroke.Path.MoveTo(lineStartPoint);
-            var left = Math.Min(lineStartPoint.X, endPoint.X);
-            var top = Math.Min(lineStartPoint.Y, endPoint.Y);
-            var rect = SKRect.Create(new SKPoint(left, top),
-                Utilities.GetSize(lineStartPoint, endPoint));
-            if (stroke.Paint.StrokeJoin == SKStrokeJoin.Miter)
-            {
-                stroke.Path.AddRect(rect);
-            }
-            else
-            {
-                stroke.Path.AddRoundRect(rect, 24f, 24f);
-            }
-        }
-        else if (stroke.ToolType == ToolType.Ellipse)
-        {
-            stroke.Path.MoveTo(lineStartPoint);
-            var left = Math.Min(lineStartPoint.X, endPoint.X);
-            var top = Math.Min(lineStartPoint.Y, endPoint.Y);
-            var rect = SKRect.Create(new SKPoint(left, top),
-                Utilities.GetSize(lineStartPoint, endPoint));
-            stroke.Path.AddOval(rect);
-        }
-        else
-        {
-            stroke.Path.MoveTo(lineStartPoint);
-            stroke.Path.LineTo(endPoint);
-
-            if (stroke.ToolType == ToolType.Arrow)
-            {
-                var (p1, p2) =
-                    ArrowTool.GetArrowHeadPoints(lineStartPoint, endPoint,
-                        stroke.Paint.StrokeWidth);
-
-                stroke.Path.MoveTo(endPoint);
-                stroke.Path.LineTo(p1);
-
-                stroke.Path.MoveTo(endPoint);
-                stroke.Path.LineTo(p2);
-            }
-        }
-    }
-
-    /// <summary>
-    /// Marks the strokes that are a target for erasure
-    /// </summary>
-    /// <param name="eraserPoint">The latest point in the eraser's stroke</param>
-    /// <param name="canvasElements">Collection of all current elements on the canvas</param>
-    /// <param name="eraserStroke">The active eraser stroke</param>
-    /// <param name="ownerFilter">SignalR connection id for the current client</param>
-    private static void CheckAndErase(SKPoint eraserPoint, IEnumerable<CanvasElement> canvasElements,
-        EraserStroke eraserStroke, string? ownerFilter = null)
-    {
-        foreach (var element in canvasElements)
-        {
-            // In multi-user mode, only erase elements the eraser's creator owns.
-            if (ownerFilter != null && element.CreatorConnectionId != ownerFilter)
-                continue;
-
-            if (element is PaintableStroke stroke)
-            {
-                var strokeId = stroke.Id;
-                var endPoints = new[] { stroke.Path[0], stroke.Path.LastPoint };
-                var isLineLike = stroke is DrawStroke ds && ds.ToolType is ToolType.Line or ToolType.Arrow;
-                if (isLineLike)
-                {
-                    if (Utilities.IsPointNearLine(eraserPoint, endPoints, 10.0f))
-                    {
-                        stroke.IsToBeErased = true;
-                        eraserStroke.Targets.Add(strokeId);
-                    }
-                }
-                else
-                {
-                    if (stroke.Path.Contains(eraserPoint.X, eraserPoint.Y) ||
-                        // For handling very small/short pencil strokes
-                        Utilities.IsPointNearLine(eraserPoint, endPoints, 10.0f))
-                    {
-                        stroke.IsToBeErased = true;
-                        eraserStroke.Targets.Add(strokeId);
-                    }
-                }
-            }
-            else if (element is CanvasImage image)
-            {
-                if (image.Bounds.Contains(eraserPoint.X, eraserPoint.Y))
-                {
-                    image.IsToBeErased = true;
-                    eraserStroke.Targets.Add(image.Id);
-                }
-            }
-        }
-    }
-
-    /// <summary>
-    /// Finds all strokes that are within the selection boundary
-    /// </summary>
-    /// <param name="boundRect">The selection bound's SKRect</param>
-    /// <param name="bound">The selection bound</param>
-    /// <param name="canvasElements">Collection of all current elements on the canvas</param>
-    /// <param name="ownerFilter">SignalR connection id for the current client</param>
-    private static void CheckAndSelect(SKRect boundRect, SelectionBound bound,
-        IEnumerable<CanvasElement> canvasElements, string? ownerFilter = null)
-    {
-        bound.Targets.Clear();
-        foreach (var element in canvasElements)
-        {
-            // In multi-user mode, only select elements the selector's creator owns.
-            if (ownerFilter != null && element.CreatorConnectionId != ownerFilter)
-                continue;
-
-            if (element is PaintableStroke stroke)
-            {
-                SKRect strokeBounds = stroke.Path.TightBounds;
-                if (boundRect.Contains(strokeBounds))
-                {
-                    bound.Targets.Add(stroke.Id);
-                }
-            }
-            else if (element is CanvasImage image)
-            {
-                if (boundRect.Contains(image.Bounds))
-                {
-                    bound.Targets.Add(image.Id);
-                }
-            }
-        }
-    }
-
-    private static void MoveElements(IEnumerable<CanvasElement> elements, SKPoint delta)
-    {
-        foreach (var canvasElement in elements)
-        {
-            if (canvasElement is PaintableStroke stroke)
-            {
-                var matrix = SKMatrix.CreateTranslation(delta.X, delta.Y);
-                stroke.Path.Transform(matrix);
-                if (stroke is TextStroke movedText)
-                {
-                    movedText.TransformMatrix = movedText.TransformMatrix.PostConcat(matrix);
-                }
-            }
-            else if (canvasElement is CanvasImage image)
-            {
-                // SKRect is a struct (value-type), so we need to create a new one to modify
-                var bounds = image.Bounds;
-                bounds.Offset(delta);
-                image.Bounds = bounds;
-            }
-        }
     }
 }

--- a/Scribble/Services/CanvasStateService/Context/FastPathContext.cs
+++ b/Scribble/Services/CanvasStateService/Context/FastPathContext.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using Scribble.Shared.Lib.CanvasElements;
+using Scribble.Shared.Lib.CanvasElements.Strokes;
+using SkiaSharp;
+
+namespace Scribble.Services.CanvasStateService.Context;
+
+/// <summary>
+/// Provides fast-path handlers with access to the live canvas state
+/// (the lookup dictionaries maintained between replays).
+/// </summary>
+public class FastPathContext
+{
+    public required Dictionary<Guid, PaintableStroke> StrokeLookup { get; init; }
+    public required Dictionary<Guid, EraserStroke> EraserStrokeLookup { get; init; }
+    public required Dictionary<Guid, SKPoint> EraserHeadLookup { get; init; }
+    public required Dictionary<Guid, SelectionBound> SelectionBoundLookup { get; init; }
+    public required Dictionary<Guid, CanvasImage> CanvasImageLookup { get; init; }
+    public required IReadOnlyList<CanvasElement> CanvasElements { get; init; }
+    public required HashSet<Guid> LocalSelectionBoundIds { get; init; }
+
+    // Callbacks the handler can invoke to signal the UI
+    public required Action? OnCanvasInvalidated { get; init; }
+    public required Action? OnSelectionInvalidated { get; init; }
+
+    public Guid? ActiveSelectionBoundId { get; set; }
+    public List<Guid>? SelectedElementIds { get; set; }
+}

--- a/Scribble/Services/CanvasStateService/Context/ReplayContext.cs
+++ b/Scribble/Services/CanvasStateService/Context/ReplayContext.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+using Scribble.Shared.Lib.CanvasElements;
+using Scribble.Shared.Lib.CanvasElements.Strokes;
+using SkiaSharp;
+
+namespace Scribble.Services.CanvasStateService.Context;
+
+/// <summary>
+/// Context for event handlers during replay
+/// </summary>
+public class ReplayContext
+{
+    public Dictionary<Guid, PaintableStroke> PaintableStrokes { get; } = new();
+    public Dictionary<Guid, EraserStroke> EraserStrokes { get; } = new();
+    public Dictionary<Guid, SKPoint> EraserHeads { get; } = new();
+    public Dictionary<Guid, SelectionBound> SelectionBounds { get; } = new();
+    public Dictionary<Guid, CanvasImage> CanvasImages { get; } = new();
+    public List<Guid> StaleActionIds { get; } = [];
+    public int MaxLayerIndex { get; set; }
+    public int MinLayerIndex { get; set; }
+}

--- a/Scribble/Services/CanvasStateService/EventReplayDispatcher.cs
+++ b/Scribble/Services/CanvasStateService/EventReplayDispatcher.cs
@@ -4,9 +4,10 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using Scribble.Services.CanvasStateService.Context;
+using Scribble.Services.CanvasStateService.Handlers;
 using Scribble.Shared.Lib;
 
-namespace Scribble.Services.CanvasStateService.Handlers;
+namespace Scribble.Services.CanvasStateService;
 
 /// <summary>
 /// Builds a Type-to-handler lookup from event handler instances using reflections

--- a/Scribble/Services/CanvasStateService/Handlers/CanvasLifecycleReplayHandler.cs
+++ b/Scribble/Services/CanvasStateService/Handlers/CanvasLifecycleReplayHandler.cs
@@ -1,0 +1,235 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia.Skia;
+using Scribble.Services.CanvasStateService.Context;
+using Scribble.Shared.Lib;
+using Scribble.Shared.Lib.CanvasElements;
+using Scribble.Shared.Lib.CanvasElements.Strokes;
+using Scribble.Utils;
+using SkiaSharp;
+
+namespace Scribble.Services.CanvasStateService.Handlers;
+
+/// <summary>
+/// Handles replay for canvas lifecycle events:
+/// LoadCanvasEvent, AddImageEvent, SetElementLayerEvent, NudgeElementLayerEvent, PasteCanvasElementsEvent
+/// </summary>
+public class CanvasLifecycleReplayHandler :
+    IEventReplayHandler<LoadCanvasEvent>,
+    IEventReplayHandler<AddImageEvent>,
+    IEventReplayHandler<SetElementLayerEvent>,
+    IEventReplayHandler<NudgeElementLayerEvent>,
+    IEventReplayHandler<PasteCanvasElementsEvent>
+{
+    public void Replay(LoadCanvasEvent ev, ReplayContext ctx)
+    {
+        ctx.PaintableStrokes.Clear();
+        ctx.CanvasImages.Clear();
+        ctx.EraserStrokes.Clear();
+        ctx.EraserHeads.Clear();
+        ctx.SelectionBounds.Clear();
+
+        foreach (var element in ev.CanvasElements)
+        {
+            switch (element)
+            {
+                case DrawStroke drawStroke:
+                    ctx.PaintableStrokes[drawStroke.Id] = new DrawStroke
+                    {
+                        Id = drawStroke.Id,
+                        Paint = drawStroke.Paint.Clone(),
+                        ToolOptions = drawStroke.ToolOptions,
+                        ToolType = drawStroke.ToolType,
+                        Path = drawStroke.Path.Clone(),
+                        RawPoints = [..drawStroke.RawPoints],
+                        LayerIndex = drawStroke.LayerIndex,
+                        CreatorConnectionId = drawStroke.CreatorConnectionId
+                    };
+                    ctx.MaxLayerIndex =
+                        Math.Max(ctx.MaxLayerIndex, ctx.PaintableStrokes[drawStroke.Id].LayerIndex);
+                    break;
+                case TextStroke loadedText:
+                    ctx.PaintableStrokes[loadedText.Id] = new TextStroke
+                    {
+                        Id = loadedText.Id,
+                        Text = loadedText.Text,
+                        Position = loadedText.Position,
+                        Paint = loadedText.Paint.Clone(),
+                        ToolOptions = loadedText.ToolOptions,
+                        Path = loadedText.Path.Clone(),
+                        LayerIndex = loadedText.LayerIndex,
+                        TransformMatrix = loadedText.TransformMatrix,
+                        IsBold = loadedText.IsBold,
+                        IsItalic = loadedText.IsItalic,
+                        CreatorConnectionId = loadedText.CreatorConnectionId
+                    };
+                    ctx.MaxLayerIndex =
+                        Math.Max(ctx.MaxLayerIndex, ctx.PaintableStrokes[loadedText.Id].LayerIndex);
+                    break;
+                case CanvasImage canvasImage:
+                    ctx.CanvasImages[canvasImage.Id] = new CanvasImage
+                    {
+                        Id = canvasImage.Id,
+                        ImageBase64String = canvasImage.ImageBase64String,
+                        Bounds = canvasImage.Bounds,
+                        Rotation = canvasImage.Rotation,
+                        FlipX = canvasImage.FlipX,
+                        FlipY = canvasImage.FlipY,
+                        LayerIndex = canvasImage.LayerIndex,
+                        CreatorConnectionId = canvasImage.CreatorConnectionId
+                    };
+                    ctx.MaxLayerIndex =
+                        Math.Max(ctx.MaxLayerIndex, ctx.CanvasImages[canvasImage.Id].LayerIndex);
+                    break;
+            }
+        }
+    }
+
+    public void Replay(AddImageEvent ev, ReplayContext ctx)
+    {
+        var imageBounds = SKRect.Create(ev.Position, ev.Size);
+        ctx.CanvasImages[ev.ImageId] = new CanvasImage
+        {
+            Id = ev.ImageId,
+            ImageBase64String = ev.ImageBase64String,
+            Bounds = imageBounds,
+            CreatorConnectionId = ev.CreatorConnectionId,
+            LayerIndex = ctx.MaxLayerIndex
+        };
+    }
+
+    public void Replay(SetElementLayerEvent ev, ReplayContext ctx)
+    {
+        foreach (var elementId in ev.TargetElementIds)
+        {
+            if (ctx.PaintableStrokes.TryGetValue(elementId, out var stroke))
+            {
+                stroke.LayerIndex = ev.NewLayerIndex;
+                ctx.MaxLayerIndex = Math.Max(ctx.MaxLayerIndex, stroke.LayerIndex);
+            }
+            else if (ctx.CanvasImages.TryGetValue(elementId, out var image))
+            {
+                image.LayerIndex = ev.NewLayerIndex;
+                ctx.MaxLayerIndex = Math.Max(ctx.MaxLayerIndex, image.LayerIndex);
+            }
+        }
+
+        ctx.MaxLayerIndex = Math.Max(ctx.MaxLayerIndex, ev.NewLayerIndex);
+        ctx.MinLayerIndex = Math.Min(ctx.MinLayerIndex, ev.NewLayerIndex);
+    }
+
+    public void Replay(NudgeElementLayerEvent ev, ReplayContext ctx)
+    {
+        var newMinLayerIndex = 0;
+        var newMaxLayerIndex = 0;
+        foreach (var elementId in ev.TargetElementIds)
+        {
+            if (ctx.PaintableStrokes.TryGetValue(elementId, out var stroke))
+            {
+                var newLayer = stroke.LayerIndex + ev.Offset;
+
+                stroke.LayerIndex = newLayer;
+                newMaxLayerIndex = Math.Max(newMaxLayerIndex, newLayer);
+                newMinLayerIndex = Math.Min(newMinLayerIndex, newLayer);
+            }
+            else if (ctx.CanvasImages.TryGetValue(elementId, out var image))
+            {
+                var newLayer = image.LayerIndex + ev.Offset;
+
+                image.LayerIndex = newLayer;
+                newMaxLayerIndex = Math.Max(newMaxLayerIndex, newLayer);
+                newMinLayerIndex = Math.Min(newMinLayerIndex, newLayer);
+            }
+        }
+
+        ctx.MinLayerIndex = Math.Min(ctx.MinLayerIndex, newMinLayerIndex);
+        ctx.MaxLayerIndex = Math.Max(ctx.MaxLayerIndex, newMaxLayerIndex);
+    }
+
+    public void Replay(PasteCanvasElementsEvent ev, ReplayContext ctx)
+    {
+        List<CanvasElement> pastedElements = [];
+        foreach (var element in ev.CopiedElements)
+        {
+            switch (element)
+            {
+                case DrawStroke pastedDrawStroke:
+                    pastedElements.Add(new DrawStroke
+                    {
+                        Id = pastedDrawStroke.Id,
+                        Paint = pastedDrawStroke.Paint.Clone(),
+                        ToolOptions = pastedDrawStroke.ToolOptions,
+                        ToolType = pastedDrawStroke.ToolType,
+                        Path = pastedDrawStroke.Path.Clone(),
+                        RawPoints = [..pastedDrawStroke.RawPoints],
+                        LayerIndex = pastedDrawStroke.LayerIndex,
+                        CreatorConnectionId = pastedDrawStroke.CreatorConnectionId
+                    });
+                    break;
+                case TextStroke pastedTextStroke:
+                    pastedElements.Add(new TextStroke
+                    {
+                        Id = pastedTextStroke.Id,
+                        Text = pastedTextStroke.Text,
+                        Position = pastedTextStroke.Position,
+                        Paint = pastedTextStroke.Paint.Clone(),
+                        ToolOptions = pastedTextStroke.ToolOptions,
+                        Path = pastedTextStroke.Path.Clone(),
+                        LayerIndex = pastedTextStroke.LayerIndex,
+                        TransformMatrix = pastedTextStroke.TransformMatrix,
+                        IsBold = pastedTextStroke.IsBold,
+                        IsItalic = pastedTextStroke.IsItalic,
+                        CreatorConnectionId = pastedTextStroke.CreatorConnectionId
+                    });
+                    break;
+                case CanvasImage pastedCanvasImage:
+                    pastedElements.Add(new CanvasImage
+                    {
+                        Id = pastedCanvasImage.Id,
+                        ImageBase64String = pastedCanvasImage.ImageBase64String,
+                        Bounds = pastedCanvasImage.Bounds,
+                        Rotation = pastedCanvasImage.Rotation,
+                        FlipX = pastedCanvasImage.FlipX,
+                        FlipY = pastedCanvasImage.FlipY,
+                        LayerIndex = pastedCanvasImage.LayerIndex,
+                        CreatorConnectionId = pastedCanvasImage.CreatorConnectionId
+                    });
+                    break;
+            }
+        }
+
+        var copiedElementsBounds = Utilities.GetElementsBounds(pastedElements);
+        var boundsMiddlePos = new SKPoint(copiedElementsBounds.MidX, copiedElementsBounds.MidY);
+        var delta = ev.Position - boundsMiddlePos;
+        // Translate all elements such that the middle of the total bound is at the pointer position
+        TransformReplayHandler.MoveElements(pastedElements, delta);
+        foreach (var copiedElement in pastedElements)
+        {
+            switch (copiedElement)
+            {
+                case PaintableStroke stroke:
+                    ctx.PaintableStrokes[stroke.Id] = stroke;
+                    break;
+                case CanvasImage image:
+                    ctx.CanvasImages[image.Id] = image;
+                    break;
+            }
+        }
+
+        // Automatically select the pasted elements
+        ctx.SelectionBounds.Clear();
+        var pasteSelectionPath = new SKPath();
+        var selectionRect = Utilities.GetElementsBounds(pastedElements);
+        pasteSelectionPath.AddRect(selectionRect);
+
+        var pasteSelectionBound = new SelectionBound
+        {
+            Id = ev.SelectionBoundId,
+            Path = pasteSelectionPath,
+            CreatorConnectionId = ev.CreatorConnectionId,
+            Targets = [..pastedElements.Select(e => e.Id)]
+        };
+        ctx.SelectionBounds[ev.SelectionBoundId] = pasteSelectionBound;
+    }
+}

--- a/Scribble/Services/CanvasStateService/Handlers/EraserReplayHandler.cs
+++ b/Scribble/Services/CanvasStateService/Handlers/EraserReplayHandler.cs
@@ -1,0 +1,176 @@
+using System;
+using System.Collections.Generic;
+using Scribble.Services.CanvasStateService.Context;
+using Scribble.Shared.Lib;
+using Scribble.Shared.Lib.CanvasElements;
+using Scribble.Shared.Lib.CanvasElements.Strokes;
+using Scribble.Utils;
+using SkiaSharp;
+
+namespace Scribble.Services.CanvasStateService.Handlers;
+
+/// <summary>
+/// Handles replay and fast-path for eraser-related events:
+/// StartEraseStrokeEvent, EraseStrokeLineToEvent, TriggerEraseEvent
+/// </summary>
+public class EraserReplayHandler :
+    IEventReplayHandler<StartEraseStrokeEvent>,
+    IEventReplayHandler<EraseStrokeLineToEvent>,
+    IEventReplayHandler<TriggerEraseEvent>,
+    IFastPathHandler<EraseStrokeLineToEvent>
+{
+    // Replay handlers
+
+    public void Replay(StartEraseStrokeEvent ev, ReplayContext ctx)
+    {
+        var eraserPath = new SKPath();
+        eraserPath.MoveTo(ev.StartPoint);
+        var newEraserStroke = new EraserStroke
+        {
+            Path = eraserPath,
+            CreatorConnectionId = ev.CreatorConnectionId
+        };
+
+        // Keep track of the eraser heads for linear interpolation
+        ctx.EraserHeads[ev.StrokeId] = ev.StartPoint;
+
+        // Find all targets for erasing
+        CheckAndErase(ev.StartPoint, [..ctx.PaintableStrokes.Values, ..ctx.CanvasImages.Values], newEraserStroke,
+            ownerFilter: ev.CreatorConnectionId);
+
+        ctx.EraserStrokes[ev.StrokeId] = newEraserStroke;
+    }
+
+    public void Replay(EraseStrokeLineToEvent ev, ReplayContext ctx)
+    {
+        if (ctx.EraserStrokes.TryGetValue(ev.StrokeId, out var currentEraserStroke))
+        {
+            // Use interpolation to find all targets for erasing
+            var start = ctx.EraserHeads[ev.StrokeId];
+            var end = ev.Point;
+            var distance = Math.Sqrt(Math.Pow(end.X - start.X, 2) + Math.Pow(end.Y - start.Y, 2));
+
+            var stepSize = 5.0;
+            var steps = (int)Math.Ceiling(distance / stepSize);
+            for (int s = 1; s <= steps; s++)
+            {
+                var completionPercentage = s / stepSize;
+                var checkX = start.X + (end.X - start.X) * completionPercentage;
+                var checkY = start.Y + (end.Y - start.Y) * completionPercentage;
+                CheckAndErase(new SKPoint((float)checkX, (float)checkY),
+                    [..ctx.PaintableStrokes.Values, ..ctx.CanvasImages.Values],
+                    currentEraserStroke,
+                    ownerFilter: currentEraserStroke.CreatorConnectionId);
+            }
+
+            currentEraserStroke.Path.LineTo(ev.Point);
+            ctx.EraserHeads[ev.StrokeId] = ev.Point;
+        }
+    }
+
+    public void Replay(TriggerEraseEvent ev, ReplayContext ctx)
+    {
+        if (ctx.EraserStrokes.TryGetValue(ev.StrokeId, out var currentEraserStroke))
+        {
+            // Erase all targets
+            foreach (var targetId in currentEraserStroke.Targets)
+            {
+                ctx.PaintableStrokes.Remove(targetId);
+                ctx.CanvasImages.Remove(targetId);
+            }
+
+            if (currentEraserStroke.Targets.Count == 0)
+            {
+                ctx.StaleActionIds.Add(ev.ActionId);
+            }
+        }
+    }
+
+    // Fast-path handler
+
+    public bool TryApplyFastPath(EraseStrokeLineToEvent ev, FastPathContext ctx)
+    {
+        if (ctx.EraserStrokeLookup.TryGetValue(ev.StrokeId, out var currentEraserStroke))
+        {
+            var start = ctx.EraserHeadLookup[ev.StrokeId];
+            var end = ev.Point;
+            var distance = Math.Sqrt(Math.Pow(end.X - start.X, 2) + Math.Pow(end.Y - start.Y, 2));
+
+            const double stepSize = 5.0;
+            var steps = (int)Math.Ceiling(distance / stepSize);
+            for (var s = 1; s <= steps; s++)
+            {
+                var completionPercentage = s / stepSize;
+                var checkX = start.X + (end.X - start.X) * completionPercentage;
+                var checkY = start.Y + (end.Y - start.Y) * completionPercentage;
+                CheckAndErase(new SKPoint((float)checkX, (float)checkY), ctx.CanvasElements, currentEraserStroke,
+                    ownerFilter: currentEraserStroke.CreatorConnectionId);
+            }
+
+            currentEraserStroke.Path.LineTo(ev.Point);
+            ctx.EraserHeadLookup[ev.StrokeId] = ev.Point;
+            ctx.OnCanvasInvalidated?.Invoke();
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Marks the strokes that are a target for erasure
+    /// </summary>
+    /// <param name="eraserPoint">The latest point in the eraser's stroke</param>
+    /// <param name="canvasElements">Collection of all current elements on the canvas</param>
+    /// <param name="eraserStroke">The active eraser stroke</param>
+    /// <param name="ownerFilter">SignalR connection id for the current client</param>
+    private static void CheckAndErase(SKPoint eraserPoint, IEnumerable<CanvasElement> canvasElements,
+        EraserStroke eraserStroke, string? ownerFilter = null)
+    {
+        foreach (var element in canvasElements)
+        {
+            // In multi-user mode, only erase elements the eraser's creator owns.
+            if (ownerFilter != null && element.CreatorConnectionId != ownerFilter)
+                continue;
+
+            switch (element)
+            {
+                case PaintableStroke stroke:
+                {
+                    var strokeId = stroke.Id;
+                    var endPoints = new[] { stroke.Path[0], stroke.Path.LastPoint };
+                    var isLineLike = stroke is DrawStroke { ToolType: ToolType.Line or ToolType.Arrow };
+                    if (isLineLike)
+                    {
+                        if (Utilities.IsPointNearLine(eraserPoint, endPoints, 10.0f))
+                        {
+                            stroke.IsToBeErased = true;
+                            eraserStroke.Targets.Add(strokeId);
+                        }
+                    }
+                    else
+                    {
+                        if (stroke.Path.Contains(eraserPoint.X, eraserPoint.Y) ||
+                            // For handling very small/short pencil strokes
+                            Utilities.IsPointNearLine(eraserPoint, endPoints, 10.0f))
+                        {
+                            stroke.IsToBeErased = true;
+                            eraserStroke.Targets.Add(strokeId);
+                        }
+                    }
+
+                    break;
+                }
+                case CanvasImage image:
+                {
+                    if (image.Bounds.Contains(eraserPoint.X, eraserPoint.Y))
+                    {
+                        image.IsToBeErased = true;
+                        eraserStroke.Targets.Add(image.Id);
+                    }
+
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/Scribble/Services/CanvasStateService/Handlers/EventReplayDispatcher.cs
+++ b/Scribble/Services/CanvasStateService/Handlers/EventReplayDispatcher.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Scribble.Services.CanvasStateService.Context;
+using Scribble.Shared.Lib;
+
+namespace Scribble.Services.CanvasStateService.Handlers;
+
+/// <summary>
+/// Builds a Type-to-handler lookup from event handler instances using reflections
+/// and provides Dispatch (for replay) and TryFastPath (for fast-path optimization).
+/// </summary>
+public class EventReplayDispatcher
+{
+    private readonly Dictionary<Type, Action<Event, ReplayContext>> _replayHandlers = new();
+    private readonly Dictionary<Type, Func<Event, FastPathContext, bool>> _fastPathHandlers = new();
+
+    public EventReplayDispatcher(params object[] handlerInstances)
+    {
+        foreach (var instance in handlerInstances)
+        {
+            RegisterHandlers(instance);
+        }
+    }
+
+    /// <summary>
+    /// Dispatch a replay event to its registered handler.
+    /// Silently skips events with no registered handler (e.g. UndoEvent, RedoEvent).
+    /// </summary>
+    public void Dispatch(Event @event, ReplayContext ctx)
+    {
+        if (_replayHandlers.TryGetValue(@event.GetType(), out var handler))
+        {
+            handler(@event, ctx);
+        }
+    }
+
+    /// <summary>
+    /// Attempt to apply a fast-path optimization for the event.
+    /// Returns true if the fast-path was applied (skipping full replay).
+    /// </summary>
+    public bool TryFastPath(Event @event, FastPathContext ctx)
+    {
+        if (_fastPathHandlers.TryGetValue(@event.GetType(), out var handler))
+        {
+            return handler(@event, ctx);
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Validates that every concrete Event subtype in the given assembly
+    /// has a registered replay handler. Throws if any are missing.
+    /// UndoEvent and RedoEvent are excluded as they are handled in the pre-pass.
+    /// </summary>
+    public void ValidateCompleteness(Assembly eventAssembly)
+    {
+        var allEventTypes = eventAssembly.GetTypes()
+            .Where(t => t.IsSubclassOf(typeof(Event)) && !t.IsAbstract)
+            .Where(t => t != typeof(UndoEvent) && t != typeof(RedoEvent))
+            .ToList();
+
+        var missing = allEventTypes
+            .Where(t => !_replayHandlers.ContainsKey(t))
+            .Select(t => t.Name)
+            .ToList();
+
+        if (missing.Count > 0)
+        {
+            throw new InvalidOperationException(
+                $"Missing replay handlers for: {string.Join(", ", missing)}");
+        }
+    }
+
+    private void RegisterHandlers(object instance)
+    {
+        var instanceType = instance.GetType();
+
+        foreach (var iface in instanceType.GetInterfaces())
+        {
+            if (!iface.IsGenericType) continue;
+
+            var genericDef = iface.GetGenericTypeDefinition();
+
+            if (genericDef == typeof(IEventReplayHandler<>))
+            {
+                var eventType = iface.GetGenericArguments()[0];
+                var method = iface.GetMethod("Replay")!;
+                var compiledDelegate = BuildReplayDelegate(instance, method, eventType);
+                _replayHandlers[eventType] = compiledDelegate;
+            }
+            else if (genericDef == typeof(IFastPathHandler<>))
+            {
+                var eventType = iface.GetGenericArguments()[0];
+                var method = iface.GetMethod("TryApplyFastPath")!;
+                var compiledDelegate = BuildFastPathDelegate(instance, method, eventType);
+                _fastPathHandlers[eventType] = compiledDelegate;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Builds a compiled delegate that casts the Event to the concrete type
+    /// and calls the handler's Replay method, avoiding reflection on every dispatch.
+    /// </summary>
+    private static Action<Event, ReplayContext> BuildReplayDelegate(
+        object instance, MethodInfo method, Type eventType)
+    {
+        var eventParam = Expression.Parameter(typeof(Event), "e");
+        var ctxParam = Expression.Parameter(typeof(ReplayContext), "ctx");
+        var castEvent = Expression.Convert(eventParam, eventType);
+        var instanceConst = Expression.Constant(instance);
+        var call = Expression.Call(instanceConst, method, castEvent, ctxParam);
+        return Expression.Lambda<Action<Event, ReplayContext>>(call, eventParam, ctxParam).Compile();
+    }
+
+    /// <summary>
+    /// Builds a compiled delegate for fast-path handlers.
+    /// </summary>
+    private static Func<Event, FastPathContext, bool> BuildFastPathDelegate(
+        object instance, MethodInfo method, Type eventType)
+    {
+        var eventParam = Expression.Parameter(typeof(Event), "e");
+        var ctxParam = Expression.Parameter(typeof(FastPathContext), "ctx");
+        var castEvent = Expression.Convert(eventParam, eventType);
+        var instanceConst = Expression.Constant(instance);
+        var call = Expression.Call(instanceConst, method, castEvent, ctxParam);
+        return Expression.Lambda<Func<Event, FastPathContext, bool>>(call, eventParam, ctxParam).Compile();
+    }
+}

--- a/Scribble/Services/CanvasStateService/Handlers/IEventReplayHandler.cs
+++ b/Scribble/Services/CanvasStateService/Handlers/IEventReplayHandler.cs
@@ -1,0 +1,13 @@
+using Scribble.Services.CanvasStateService.Context;
+using Scribble.Shared.Lib;
+
+namespace Scribble.Services.CanvasStateService.Handlers;
+
+/// <summary>
+/// Handles the replay of a specific event type by applying its
+/// effect to the ReplayContext during a full event-log rebuild.
+/// </summary>
+public interface IEventReplayHandler<in TEvent> where TEvent : Event
+{
+    void Replay(TEvent @event, ReplayContext ctx);
+}

--- a/Scribble/Services/CanvasStateService/Handlers/IFastPathHandler.cs
+++ b/Scribble/Services/CanvasStateService/Handlers/IFastPathHandler.cs
@@ -1,0 +1,14 @@
+using Scribble.Services.CanvasStateService.Context;
+using Scribble.Shared.Lib;
+
+namespace Scribble.Services.CanvasStateService.Handlers;
+
+/// <summary>
+/// Applies a fast-path optimization for a specific event type
+/// by directly mutating the live canvas state (lookup dictionaries)
+/// without triggering a full replay.
+/// </summary>
+public interface IFastPathHandler<in TEvent> where TEvent : Event
+{
+    bool TryApplyFastPath(TEvent @event, FastPathContext ctx);
+}

--- a/Scribble/Services/CanvasStateService/Handlers/PropertyReplayHandler.cs
+++ b/Scribble/Services/CanvasStateService/Handlers/PropertyReplayHandler.cs
@@ -1,0 +1,110 @@
+using System;
+using Scribble.Services.CanvasStateService.Context;
+using Scribble.Shared.Lib;
+using Scribble.Utils;
+using SkiaSharp;
+
+namespace Scribble.Services.CanvasStateService.Handlers;
+
+/// <summary>
+/// Handles replay for stroke property update events:
+/// UpdateStrokeColorEvent, UpdateStrokeThicknessEvent, UpdateStrokeStyleEvent,
+/// UpdateStrokeFillColorEvent, UpdateStrokeEdgeTypeEvent
+/// </summary>
+public class PropertyReplayHandler :
+    IEventReplayHandler<UpdateStrokeColorEvent>,
+    IEventReplayHandler<UpdateStrokeThicknessEvent>,
+    IEventReplayHandler<UpdateStrokeStyleEvent>,
+    IEventReplayHandler<UpdateStrokeFillColorEvent>,
+    IEventReplayHandler<UpdateStrokeEdgeTypeEvent>
+{
+    public void Replay(UpdateStrokeColorEvent ev, ReplayContext ctx)
+    {
+        foreach (var strokeId in ev.StrokeIds)
+        {
+            ctx.PaintableStrokes[strokeId].Paint.Color = ev.NewColor;
+        }
+    }
+
+    public void Replay(UpdateStrokeThicknessEvent ev, ReplayContext ctx)
+    {
+        foreach (var strokeId in ev.StrokeIds)
+        {
+            ctx.PaintableStrokes[strokeId].Paint.StrokeWidth = ev.NewThickness;
+        }
+    }
+
+    public void Replay(UpdateStrokeStyleEvent ev, ReplayContext ctx)
+    {
+        foreach (var strokeId in ev.StrokeIds)
+        {
+            ctx.PaintableStrokes[strokeId].Paint.DashIntervals = ev.NewDashIntervals;
+        }
+    }
+
+    public void Replay(UpdateStrokeFillColorEvent ev, ReplayContext ctx)
+    {
+        foreach (var strokeId in ev.StrokeIds)
+        {
+            ctx.PaintableStrokes[strokeId].Paint.FillColor = ev.NewFillColor;
+        }
+    }
+
+    public void Replay(UpdateStrokeEdgeTypeEvent ev, ReplayContext ctx)
+    {
+        foreach (var strokeId in ev.StrokeIds)
+        {
+            var stroke = ctx.PaintableStrokes[strokeId];
+            stroke.Paint.StrokeJoin = ev.NewStrokeJoin;
+            // Recreate the stroke paths, preserving any rotation
+
+            // Detect a rotation angle if any from the first edge of the rect/roundrect sub-path
+            var points = stroke.Path.Points;
+            var rotationAngle = (float)Math.Atan2(
+                points[2].Y - points[1].Y,
+                points[2].X - points[1].X);
+
+            // Un-rotate around the shape's center to recover axis-aligned dimensions
+            var center = new SKPoint(
+                stroke.Path.TightBounds.MidX,
+                stroke.Path.TightBounds.MidY);
+
+            using var unrotatedPath = new SKPath(stroke.Path);
+            if (Math.Abs(rotationAngle) > 0.001f)
+            {
+                unrotatedPath.Transform(
+                    SKMatrix.CreateRotation(-rotationAngle, center.X, center.Y));
+            }
+
+            var bounds = unrotatedPath.Bounds;
+            var lineStartPoint = unrotatedPath.Points[0];
+            var lineEndPoint = new SKPoint(
+                bounds.Left + bounds.Right - lineStartPoint.X,
+                bounds.Top + bounds.Bottom - lineStartPoint.Y
+            );
+
+            // Rebuild the path with the new edge type
+            stroke.Path.Reset();
+            stroke.Path.MoveTo(lineStartPoint);
+            var left = Math.Min(lineStartPoint.X, lineEndPoint.X);
+            var top = Math.Min(lineStartPoint.Y, lineEndPoint.Y);
+            var rect = SKRect.Create(new SKPoint(left, top),
+                Utilities.GetSize(lineStartPoint, lineEndPoint));
+            if (stroke.Paint.StrokeJoin == SKStrokeJoin.Miter)
+            {
+                stroke.Path.AddRect(rect);
+            }
+            else
+            {
+                stroke.Path.AddRoundRect(rect, 24f, 24f);
+            }
+
+            // Re-apply the rotation
+            if (Math.Abs(rotationAngle) > 0.001f)
+            {
+                stroke.Path.Transform(
+                    SKMatrix.CreateRotation(rotationAngle, center.X, center.Y));
+            }
+        }
+    }
+}

--- a/Scribble/Services/CanvasStateService/Handlers/SelectionReplayHandler.cs
+++ b/Scribble/Services/CanvasStateService/Handlers/SelectionReplayHandler.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Scribble.Services.CanvasStateService.Context;
+using Scribble.Shared.Lib;
+using Scribble.Shared.Lib.CanvasElements;
+using Scribble.Shared.Lib.CanvasElements.Strokes;
+using Scribble.Utils;
+using SkiaSharp;
+
+namespace Scribble.Services.CanvasStateService.Handlers;
+
+/// <summary>
+/// Handles replay and fast-path for selection-related events:
+/// CreateSelectionBoundEvent, IncreaseSelectionBoundEvent, EndSelectionEvent, ClearSelectionEvent
+/// </summary>
+public class SelectionReplayHandler :
+    IEventReplayHandler<CreateSelectionBoundEvent>,
+    IEventReplayHandler<IncreaseSelectionBoundEvent>,
+    IEventReplayHandler<EndSelectionEvent>,
+    IEventReplayHandler<ClearSelectionEvent>,
+    IFastPathHandler<IncreaseSelectionBoundEvent>
+{
+    // Replay handlers
+
+    public void Replay(CreateSelectionBoundEvent ev, ReplayContext ctx)
+    {
+        var selectionPath = new SKPath();
+        selectionPath.MoveTo(ev.StartPoint);
+
+        ctx.SelectionBounds.Clear();
+
+        var selectionBound = new SelectionBound
+        {
+            Id = ev.BoundId,
+            Path = selectionPath,
+            CreatorConnectionId = ev.CreatorConnectionId
+        };
+        ctx.SelectionBounds[ev.BoundId] = selectionBound;
+    }
+
+    public void Replay(IncreaseSelectionBoundEvent ev, ReplayContext ctx)
+    {
+        if (ctx.SelectionBounds.TryGetValue(ev.BoundId, out var bound))
+        {
+            var boundOrigin = bound.Path.Points[0];
+            bound.Path.Reset();
+            bound.Path.MoveTo(boundOrigin);
+            bound.Path.LineTo(ev.Point);
+
+            // Check for strokes that are within this bound
+            var top = Math.Min(boundOrigin.Y, ev.Point.Y);
+            var left = Math.Min(boundOrigin.X, ev.Point.X);
+            var boundRect = SKRect.Create(new SKPoint(left, top), Utilities.GetSize(boundOrigin, ev.Point));
+            CheckAndSelect(boundRect, bound, [..ctx.PaintableStrokes.Values, ..ctx.CanvasImages.Values],
+                ownerFilter: bound.CreatorConnectionId);
+        }
+    }
+
+    public void Replay(EndSelectionEvent ev, ReplayContext ctx)
+    {
+        if (ctx.SelectionBounds.TryGetValue(ev.BoundId, out var bound))
+        {
+            if (bound.Targets.Count == 0)
+            {
+                ctx.StaleActionIds.Add(ev.ActionId);
+            }
+        }
+    }
+
+    public void Replay(ClearSelectionEvent ev, ReplayContext ctx)
+    {
+        ctx.SelectionBounds.Clear();
+    }
+
+    // Fast-path handler
+
+    public bool TryApplyFastPath(IncreaseSelectionBoundEvent ev, FastPathContext ctx)
+    {
+        if (ctx.SelectionBoundLookup.TryGetValue(ev.BoundId, out var bound))
+        {
+            var boundOrigin = bound.Path.Points[0];
+            bound.Path.Reset();
+            bound.Path.MoveTo(boundOrigin);
+            bound.Path.LineTo(ev.Point);
+
+            var top = Math.Min(boundOrigin.Y, ev.Point.Y);
+            var left = Math.Min(boundOrigin.X, ev.Point.X);
+            var boundRect = SKRect.Create(new SKPoint(left, top),
+                Utilities.GetSize(boundOrigin, ev.Point));
+            CheckAndSelect(boundRect, bound, ctx.CanvasElements,
+                ownerFilter: bound.CreatorConnectionId);
+
+            var myBound =
+                ctx.SelectionBoundLookup.FirstOrDefault(pair => ctx.LocalSelectionBoundIds.Contains(pair.Key));
+            ctx.ActiveSelectionBoundId = myBound.Value != null ? myBound.Key : null;
+            ctx.SelectedElementIds = myBound.Value?.Targets.ToList() ?? [];
+            ctx.OnSelectionInvalidated?.Invoke();
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Finds all strokes that are within the selection boundary
+    /// </summary>
+    /// <param name="boundRect">The selection bound's SKRect</param>
+    /// <param name="bound">The selection bound</param>
+    /// <param name="canvasElements">Collection of all current elements on the canvas</param>
+    /// <param name="ownerFilter">SignalR connection id for the current client</param>
+    private static void CheckAndSelect(SKRect boundRect, SelectionBound bound,
+        IEnumerable<CanvasElement> canvasElements, string? ownerFilter = null)
+    {
+        bound.Targets.Clear();
+        foreach (var element in canvasElements)
+        {
+            // In multi-user mode, only select elements the selector's creator owns.
+            if (ownerFilter != null && element.CreatorConnectionId != ownerFilter)
+                continue;
+
+            switch (element)
+            {
+                case PaintableStroke stroke:
+                {
+                    var strokeBounds = stroke.Path.TightBounds;
+                    if (boundRect.Contains(strokeBounds))
+                    {
+                        bound.Targets.Add(stroke.Id);
+                    }
+
+                    break;
+                }
+                case CanvasImage image:
+                {
+                    if (boundRect.Contains(image.Bounds))
+                    {
+                        bound.Targets.Add(image.Id);
+                    }
+
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/Scribble/Services/CanvasStateService/Handlers/StrokeReplayHandler.cs
+++ b/Scribble/Services/CanvasStateService/Handlers/StrokeReplayHandler.cs
@@ -1,0 +1,154 @@
+using System;
+using Scribble.Services.CanvasStateService.Context;
+using Scribble.Shared.Lib;
+using Scribble.Shared.Lib.CanvasElements.Strokes;
+using Scribble.Tools.PointerTools.ArrowTool;
+using Scribble.Utils;
+using SkiaSharp;
+
+namespace Scribble.Services.CanvasStateService.Handlers;
+
+/// <summary>
+/// Handles replay and fast-path for stroke-related events:
+/// StartStrokeEvent, PencilStrokeLineToEvent, LineStrokeLineToEvent, EndStrokeEvent
+/// </summary>
+public class StrokeReplayHandler :
+    IEventReplayHandler<StartStrokeEvent>,
+    IEventReplayHandler<PencilStrokeLineToEvent>,
+    IEventReplayHandler<LineStrokeLineToEvent>,
+    IEventReplayHandler<EndStrokeEvent>,
+    IFastPathHandler<PencilStrokeLineToEvent>,
+    IFastPathHandler<LineStrokeLineToEvent>
+{
+    // Replay handlers
+
+    public void Replay(StartStrokeEvent ev, ReplayContext ctx)
+    {
+        var newLinePath = new SKPath();
+        newLinePath.MoveTo(ev.StartPoint);
+        ctx.PaintableStrokes[ev.StrokeId] = new DrawStroke
+        {
+            Id = ev.StrokeId,
+            Paint = ev.StrokePaint.Clone(),
+            Path = newLinePath,
+            RawPoints = [new StrokePoint(ev.StartPoint, ev.TimeStamp.Ticks / TimeSpan.TicksPerMillisecond)],
+            ToolType = ev.ToolType,
+            ToolOptions = ev.ToolOptions,
+            CreatorConnectionId = ev.CreatorConnectionId,
+            LayerIndex = ctx.MaxLayerIndex
+        };
+    }
+
+    public void Replay(PencilStrokeLineToEvent ev, ReplayContext ctx)
+    {
+        if (ctx.PaintableStrokes.TryGetValue(ev.StrokeId, out var pStroke) && pStroke is DrawStroke dsPencil)
+        {
+            dsPencil.RawPoints.Add(new StrokePoint(ev.Point,
+                ev.TimeStamp.Ticks / TimeSpan.TicksPerMillisecond));
+            var newPath = FreehandPathBuilder.Build(dsPencil.RawPoints);
+            dsPencil.Path.Reset();
+            dsPencil.Path.AddPath(newPath);
+        }
+    }
+
+    public void Replay(LineStrokeLineToEvent ev, ReplayContext ctx)
+    {
+        if (ctx.PaintableStrokes.TryGetValue(ev.StrokeId, out var paintableStroke) &&
+            paintableStroke is DrawStroke ds)
+        {
+            RebuildLinePath(ds, ev.EndPoint);
+        }
+    }
+
+    public void Replay(EndStrokeEvent ev, ReplayContext ctx)
+    {
+        // EndStrokeEvent has no replay effect on canvas state.
+        // It exists only as a terminal event marker for undo/redo tracking.
+    }
+
+    // Fast-path handlers
+
+    public bool TryApplyFastPath(PencilStrokeLineToEvent ev, FastPathContext ctx)
+    {
+        if (ctx.StrokeLookup.TryGetValue(ev.StrokeId, out var stroke) && stroke is DrawStroke ds)
+        {
+            ds.RawPoints.Add(new StrokePoint(ev.Point,
+                ev.TimeStamp.Ticks / TimeSpan.TicksPerMillisecond));
+            var newPath = FreehandPathBuilder.Build(ds.RawPoints);
+            ds.Path.Reset();
+            ds.Path.AddPath(newPath);
+
+            ctx.OnCanvasInvalidated?.Invoke();
+            return true;
+        }
+
+        return false;
+    }
+
+    public bool TryApplyFastPath(LineStrokeLineToEvent ev, FastPathContext ctx)
+    {
+        if (ctx.StrokeLookup.TryGetValue(ev.StrokeId, out var stroke) && stroke is DrawStroke drawStroke)
+        {
+            RebuildLinePath(drawStroke, ev.EndPoint);
+            ctx.OnCanvasInvalidated?.Invoke();
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Builds the path for strokes: Rectangles, Ellipses, Lines, and Arrows
+    /// </summary>
+    /// <param name="stroke">The DrawStroke object</param>
+    /// <param name="endPoint">The line endpoint</param>
+    private static void RebuildLinePath(DrawStroke stroke, SKPoint endPoint)
+    {
+        var lineStartPoint = stroke.Path.Points[0];
+        stroke.Path.Reset();
+
+        if (stroke.ToolType == ToolType.Rectangle)
+        {
+            stroke.Path.MoveTo(lineStartPoint);
+            var left = Math.Min(lineStartPoint.X, endPoint.X);
+            var top = Math.Min(lineStartPoint.Y, endPoint.Y);
+            var rect = SKRect.Create(new SKPoint(left, top),
+                Utilities.GetSize(lineStartPoint, endPoint));
+            if (stroke.Paint.StrokeJoin == SKStrokeJoin.Miter)
+            {
+                stroke.Path.AddRect(rect);
+            }
+            else
+            {
+                stroke.Path.AddRoundRect(rect, 24f, 24f);
+            }
+        }
+        else if (stroke.ToolType == ToolType.Ellipse)
+        {
+            stroke.Path.MoveTo(lineStartPoint);
+            var left = Math.Min(lineStartPoint.X, endPoint.X);
+            var top = Math.Min(lineStartPoint.Y, endPoint.Y);
+            var rect = SKRect.Create(new SKPoint(left, top),
+                Utilities.GetSize(lineStartPoint, endPoint));
+            stroke.Path.AddOval(rect);
+        }
+        else
+        {
+            stroke.Path.MoveTo(lineStartPoint);
+            stroke.Path.LineTo(endPoint);
+
+            if (stroke.ToolType == ToolType.Arrow)
+            {
+                var (p1, p2) =
+                    ArrowTool.GetArrowHeadPoints(lineStartPoint, endPoint,
+                        stroke.Paint.StrokeWidth);
+
+                stroke.Path.MoveTo(endPoint);
+                stroke.Path.LineTo(p1);
+
+                stroke.Path.MoveTo(endPoint);
+                stroke.Path.LineTo(p2);
+            }
+        }
+    }
+}

--- a/Scribble/Services/CanvasStateService/Handlers/TextReplayHandler.cs
+++ b/Scribble/Services/CanvasStateService/Handlers/TextReplayHandler.cs
@@ -1,0 +1,148 @@
+using System;
+using Scribble.Services.CanvasStateService.Context;
+using Scribble.Shared.Lib;
+using Scribble.Shared.Lib.CanvasElements.Strokes;
+using Scribble.Utils;
+using SkiaSharp;
+
+namespace Scribble.Services.CanvasStateService.Handlers;
+
+/// <summary>
+/// Handles replay for text-related events:
+/// AddTextEvent, UpdateTextEvent, UpdateFontSizeEvent, UpdateFontCasingEvent, UpdateFontStyleEvent
+/// </summary>
+public class TextReplayHandler :
+    IEventReplayHandler<AddTextEvent>,
+    IEventReplayHandler<UpdateTextEvent>,
+    IEventReplayHandler<UpdateFontSizeEvent>,
+    IEventReplayHandler<UpdateFontCasingEvent>,
+    IEventReplayHandler<UpdateFontStyleEvent>
+{
+    public void Replay(AddTextEvent ev, ReplayContext ctx)
+    {
+        var textPath = new SKPath();
+        textPath.MoveTo(ev.Position);
+        textPath.AddPath(
+            TextPathBuilder.Build(ev.Text, ev.Position.X, ev.Position.Y, ev.Paint.TextSize,
+                StrokePaint.DefaultTypeFace));
+        ctx.PaintableStrokes[ev.StrokeId] = new TextStroke
+        {
+            Id = ev.StrokeId,
+            Paint = ev.Paint.Clone(),
+            Path = textPath,
+            ToolOptions = ev.ToolOptions,
+            Text = ev.Text,
+            Position = ev.Position,
+            CreatorConnectionId = ev.CreatorConnectionId,
+            LayerIndex = ctx.MaxLayerIndex
+        };
+    }
+
+    public void Replay(UpdateTextEvent ev, ReplayContext ctx)
+    {
+        if (ctx.PaintableStrokes.TryGetValue(ev.TextStrokeId, out var existingStroke) &&
+            existingStroke is TextStroke textStroke)
+        {
+            textStroke.Text = ev.NewText;
+            var updateTextTypeface = SKTypeface.FromFamilyName(
+                StrokePaint.DefaultTypeFace.FamilyName, textStroke.SkFontStyle);
+            var newTextPath = new SKPath();
+            newTextPath.MoveTo(textStroke.Position);
+            newTextPath.AddPath(
+                TextPathBuilder.Build(ev.NewText, textStroke.Position.X, textStroke.Position.Y,
+                    textStroke.Paint.TextSize, updateTextTypeface));
+
+            newTextPath.Transform(textStroke.TransformMatrix);
+
+            textStroke.Path.Reset();
+            textStroke.Path.AddPath(newTextPath);
+        }
+    }
+
+    public void Replay(UpdateFontSizeEvent ev, ReplayContext ctx)
+    {
+        foreach (var strokeId in ev.StrokeIds)
+        {
+            if (ctx.PaintableStrokes.TryGetValue(strokeId, out var stroke) && stroke is TextStroke ts)
+            {
+                var fontSizeTypeface = SKTypeface.FromFamilyName(
+                    StrokePaint.DefaultTypeFace.FamilyName, ts.SkFontStyle);
+                var noTransformTextPath = new SKPath();
+                noTransformTextPath.MoveTo(ts.Position);
+                noTransformTextPath.AddPath(
+                    TextPathBuilder.Build(ts.Text, ts.Position.X, ts.Position.Y, ev.FontSize,
+                        fontSizeTypeface));
+                noTransformTextPath.Transform(ts.TransformMatrix);
+                ts.Path.Reset();
+                ts.Path.AddPath(noTransformTextPath);
+            }
+        }
+    }
+
+    public void Replay(UpdateFontCasingEvent ev, ReplayContext ctx)
+    {
+        foreach (var strokeId in ev.TextStrokeIds)
+        {
+            if (ctx.PaintableStrokes.TryGetValue(strokeId, out var stroke) && stroke is TextStroke ts)
+            {
+                ts.Text = ev.NewCasing == FontCasing.UpperCase ? ts.Text.ToUpper() : ts.Text.ToLower();
+
+                // Recreate stroke paths
+                var casingTypeface = SKTypeface.FromFamilyName(
+                    StrokePaint.DefaultTypeFace.FamilyName, ts.SkFontStyle);
+                var newTextPath = new SKPath();
+                newTextPath.MoveTo(ts.Position);
+                newTextPath.AddPath(
+                    TextPathBuilder.Build(ts.Text, ts.Position.X, ts.Position.Y,
+                        ts.Paint.TextSize, casingTypeface));
+
+                newTextPath.Transform(ts.TransformMatrix);
+
+                ts.Path.Reset();
+                ts.Path.AddPath(newTextPath);
+            }
+        }
+    }
+
+    public void Replay(UpdateFontStyleEvent ev, ReplayContext ctx)
+    {
+        foreach (var strokeId in ev.TextStrokeIds)
+        {
+            if (ctx.PaintableStrokes.TryGetValue(strokeId, out var stroke) && stroke is TextStroke ts)
+            {
+                if (ev.NewStyle == FontStyle.Normal)
+                {
+                    // resets both bold and italic
+                    ts.IsBold = false;
+                    ts.IsItalic = false;
+                }
+                else if (ev.NewStyle == FontStyle.Bold)
+                {
+                    // Toggle bold
+                    ts.IsBold = !ts.IsBold;
+                }
+                else if (ev.NewStyle == FontStyle.Italic)
+                {
+                    // Toggle italic
+                    ts.IsItalic = !ts.IsItalic;
+                }
+
+                // Derive typeface from the updated bold/italic state
+                var newTypeFace = SKTypeface.FromFamilyName(
+                    StrokePaint.DefaultTypeFace.FamilyName, ts.SkFontStyle);
+
+                // Recreate stroke paths
+                var newTextPath = new SKPath();
+                newTextPath.MoveTo(ts.Position);
+                newTextPath.AddPath(
+                    TextPathBuilder.Build(ts.Text, ts.Position.X, ts.Position.Y,
+                        ts.Paint.TextSize, newTypeFace));
+
+                newTextPath.Transform(ts.TransformMatrix);
+
+                ts.Path.Reset();
+                ts.Path.AddPath(newTextPath);
+            }
+        }
+    }
+}

--- a/Scribble/Services/CanvasStateService/Handlers/TransformReplayHandler.cs
+++ b/Scribble/Services/CanvasStateService/Handlers/TransformReplayHandler.cs
@@ -1,0 +1,271 @@
+using System;
+using System.Collections.Generic;
+using Scribble.Services.CanvasStateService.Context;
+using Scribble.Shared.Lib;
+using Scribble.Shared.Lib.CanvasElements;
+using Scribble.Shared.Lib.CanvasElements.Strokes;
+using SkiaSharp;
+
+namespace Scribble.Services.CanvasStateService.Handlers;
+
+/// <summary>
+/// Handles replay and fast-path for transform-related events:
+/// MoveCanvasElementsEvent, RotateCanvasElementsEvent, ScaleCanvasElementsEvent
+/// </summary>
+public class TransformReplayHandler :
+    IEventReplayHandler<MoveCanvasElementsEvent>,
+    IEventReplayHandler<RotateCanvasElementsEvent>,
+    IEventReplayHandler<ScaleCanvasElementsEvent>,
+    IFastPathHandler<MoveCanvasElementsEvent>,
+    IFastPathHandler<RotateCanvasElementsEvent>,
+    IFastPathHandler<ScaleCanvasElementsEvent>
+{
+    // Replay handlers
+
+    public void Replay(MoveCanvasElementsEvent ev, ReplayContext ctx)
+    {
+        if (ctx.SelectionBounds.TryGetValue(ev.BoundId, out var bound))
+        {
+            List<CanvasElement> elements = [];
+            foreach (var boundTargetId in bound.Targets)
+            {
+                if (ctx.PaintableStrokes.TryGetValue(boundTargetId, out var stroke))
+                {
+                    elements.Add(stroke);
+                }
+                else if (ctx.CanvasImages.TryGetValue(boundTargetId, out var image))
+                {
+                    elements.Add(image);
+                }
+            }
+
+            MoveElements(elements, ev.Delta);
+        }
+    }
+
+    public void Replay(RotateCanvasElementsEvent ev, ReplayContext ctx)
+    {
+        if (ctx.SelectionBounds.TryGetValue(ev.BoundId, out var bound))
+        {
+            foreach (var boundTargetId in bound.Targets)
+            {
+                if (ctx.PaintableStrokes.TryGetValue(boundTargetId, out var stroke))
+                {
+                    var matrix = SKMatrix.CreateRotation(ev.DegreesRad, ev.Center.X, ev.Center.Y);
+                    stroke.Path.Transform(matrix);
+                    if (stroke is TextStroke rotatedText)
+                    {
+                        rotatedText.TransformMatrix = rotatedText.TransformMatrix.PostConcat(matrix);
+                    }
+                }
+                else if (ctx.CanvasImages.TryGetValue(boundTargetId, out var image))
+                {
+                    image.Rotation += ev.DegreesRad;
+
+                    // Rotate the bounds center around the rotation pivot
+                    var imgCenter = new SKPoint(image.Bounds.MidX, image.Bounds.MidY);
+                    var rotated = SKMatrix.CreateRotation(ev.DegreesRad, ev.Center.X, ev.Center.Y)
+                        .MapPoint(imgCenter);
+                    var bounds = image.Bounds;
+                    bounds.Offset(rotated.X - imgCenter.X, rotated.Y - imgCenter.Y);
+                    image.Bounds = bounds;
+                }
+            }
+        }
+    }
+
+    public void Replay(ScaleCanvasElementsEvent ev, ReplayContext ctx)
+    {
+        if (ctx.SelectionBounds.TryGetValue(ev.BoundId, out var bound))
+        {
+            foreach (var boundTargetId in bound.Targets)
+            {
+                if (ctx.PaintableStrokes.TryGetValue(boundTargetId, out var stroke))
+                {
+                    var matrix = SKMatrix.CreateScale(ev.Scale.X, ev.Scale.Y, ev.Center.X, ev.Center.Y);
+                    stroke.Path.Transform(matrix);
+                    if (stroke is TextStroke scaledText)
+                    {
+                        scaledText.TransformMatrix = scaledText.TransformMatrix.PostConcat(matrix);
+                    }
+                }
+                else if (ctx.CanvasImages.TryGetValue(boundTargetId, out var image))
+                {
+                    var scaleMatrix =
+                        SKMatrix.CreateScale(ev.Scale.X, ev.Scale.Y, ev.Center.X, ev.Center.Y);
+                    var topLeft = scaleMatrix.MapPoint(new SKPoint(image.Bounds.Left, image.Bounds.Top));
+                    var bottomRight =
+                        scaleMatrix.MapPoint(new SKPoint(image.Bounds.Right, image.Bounds.Bottom));
+
+                    // If the x-axis becomes inverted, swap the x coordinates so that the bound's width stays positive
+                    // Then flip the image horizontally
+                    if (topLeft.X > bottomRight.X)
+                    {
+                        (topLeft.X, bottomRight.X) = (bottomRight.X, topLeft.X);
+                        image.FlipX = !image.FlipX;
+                    }
+
+                    // If the y-axis becomes inverted, swap the y coordinates so that the bound's height stays positive
+                    // Then flip the image vertically
+                    if (topLeft.Y > bottomRight.Y)
+                    {
+                        (topLeft.Y, bottomRight.Y) = (bottomRight.Y, topLeft.Y);
+                        image.FlipY = !image.FlipY;
+                    }
+
+                    image.Bounds = new SKRect(topLeft.X, topLeft.Y, bottomRight.X, bottomRight.Y);
+                }
+            }
+        }
+    }
+
+    // Fast-path handlers
+
+    public bool TryApplyFastPath(MoveCanvasElementsEvent ev, FastPathContext ctx)
+    {
+        if (ctx.SelectionBoundLookup.TryGetValue(ev.BoundId, out var bound))
+        {
+            foreach (var boundTargetId in bound.Targets)
+            {
+                if (ctx.StrokeLookup.TryGetValue(boundTargetId, out var stroke))
+                {
+                    var matrix = SKMatrix.CreateTranslation(ev.Delta.X, ev.Delta.Y);
+                    stroke.Path.Transform(matrix);
+                    if (stroke is TextStroke textStroke)
+                    {
+                        textStroke.TransformMatrix = textStroke.TransformMatrix.PostConcat(matrix);
+                    }
+                }
+                else if (ctx.CanvasImageLookup.TryGetValue(boundTargetId, out var image))
+                {
+                    var bounds = image.Bounds;
+                    bounds.Offset(ev.Delta);
+                    image.Bounds = bounds;
+                }
+            }
+
+            ctx.OnCanvasInvalidated?.Invoke();
+            ctx.OnSelectionInvalidated?.Invoke();
+            return true;
+        }
+
+        return false;
+    }
+
+    public bool TryApplyFastPath(RotateCanvasElementsEvent ev, FastPathContext ctx)
+    {
+        if (ctx.SelectionBoundLookup.TryGetValue(ev.BoundId, out var bound))
+        {
+            foreach (var boundTargetId in bound.Targets)
+            {
+                if (ctx.StrokeLookup.TryGetValue(boundTargetId, out var stroke))
+                {
+                    var matrix = SKMatrix.CreateRotation(ev.DegreesRad, ev.Center.X,
+                        ev.Center.Y);
+                    stroke.Path.Transform(matrix);
+                    if (stroke is TextStroke textStroke)
+                    {
+                        textStroke.TransformMatrix = textStroke.TransformMatrix.PostConcat(matrix);
+                    }
+                }
+                else if (ctx.CanvasImageLookup.TryGetValue(boundTargetId, out var image))
+                {
+                    image.Rotation += ev.DegreesRad;
+                    var imgCenter = new SKPoint(image.Bounds.MidX, image.Bounds.MidY);
+                    var rotated = SKMatrix
+                        .CreateRotation(ev.DegreesRad, ev.Center.X, ev.Center.Y)
+                        .MapPoint(imgCenter);
+                    var bounds = image.Bounds;
+                    bounds.Offset(rotated.X - imgCenter.X, rotated.Y - imgCenter.Y);
+                    image.Bounds = bounds;
+                }
+            }
+
+            ctx.OnCanvasInvalidated?.Invoke();
+            ctx.OnSelectionInvalidated?.Invoke();
+            return true;
+        }
+
+        return false;
+    }
+
+    public bool TryApplyFastPath(ScaleCanvasElementsEvent ev, FastPathContext ctx)
+    {
+        if (ctx.SelectionBoundLookup.TryGetValue(ev.BoundId, out var bound))
+        {
+            foreach (var boundTargetId in bound.Targets)
+            {
+                if (ctx.StrokeLookup.TryGetValue(boundTargetId, out var stroke))
+                {
+                    var matrix = SKMatrix.CreateScale(ev.Scale.X, ev.Scale.Y, ev.Center.X,
+                        ev.Center.Y);
+                    stroke.Path.Transform(matrix);
+                    if (stroke is TextStroke textStroke)
+                    {
+                        textStroke.TransformMatrix = textStroke.TransformMatrix.PostConcat(matrix);
+                    }
+                }
+                else if (ctx.CanvasImageLookup.TryGetValue(boundTargetId, out var image))
+                {
+                    var scaleMatrix = SKMatrix.CreateScale(ev.Scale.X, ev.Scale.Y,
+                        ev.Center.X, ev.Center.Y);
+                    var topLeft = scaleMatrix.MapPoint(new SKPoint(image.Bounds.Left, image.Bounds.Top));
+                    var bottomRight =
+                        scaleMatrix.MapPoint(new SKPoint(image.Bounds.Right, image.Bounds.Bottom));
+
+                    if (topLeft.X > bottomRight.X)
+                    {
+                        (topLeft.X, bottomRight.X) = (bottomRight.X, topLeft.X);
+                        image.FlipX = !image.FlipX;
+                    }
+
+                    if (topLeft.Y > bottomRight.Y)
+                    {
+                        (topLeft.Y, bottomRight.Y) = (bottomRight.Y, topLeft.Y);
+                        image.FlipY = !image.FlipY;
+                    }
+
+                    image.Bounds = new SKRect(topLeft.X, topLeft.Y, bottomRight.X, bottomRight.Y);
+                }
+            }
+
+            ctx.OnCanvasInvalidated?.Invoke();
+            ctx.OnSelectionInvalidated?.Invoke();
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Translates a collection of canvas elements by the given delta
+    /// </summary>
+    internal static void MoveElements(IEnumerable<CanvasElement> elements, SKPoint delta)
+    {
+        foreach (var canvasElement in elements)
+        {
+            switch (canvasElement)
+            {
+                case PaintableStroke stroke:
+                {
+                    var matrix = SKMatrix.CreateTranslation(delta.X, delta.Y);
+                    stroke.Path.Transform(matrix);
+                    if (stroke is TextStroke movedText)
+                    {
+                        movedText.TransformMatrix = movedText.TransformMatrix.PostConcat(matrix);
+                    }
+
+                    break;
+                }
+                case CanvasImage image:
+                {
+                    // SKRect is a struct (value-type), so we need to create a new one to modify
+                    var bounds = image.Bounds;
+                    bounds.Offset(delta);
+                    image.Bounds = bounds;
+                    break;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces a new event handler and context system for the canvas state service, enabling more modular and efficient handling of canvas events, including support for fast-path optimizations. The main changes are the introduction of generic event handler interfaces, context classes for replay and fast-path handling, and a reflection-based dispatcher to route events to their appropriate handlers.

**Core infrastructure for event handling:**

* Added `IEventReplayHandler<TEvent>` interface to define a contract for replaying events onto the canvas state (`IEventReplayHandler.cs`).
* Added `ReplayContext` and `FastPathContext` classes to encapsulate the state and lookups needed for event replay and fast-path processing (`ReplayContext.cs`, `FastPathContext.cs`).
* Introduced `EventReplayDispatcher`, which uses reflection to build a mapping from event types to their handlers and provides methods to dispatch events for replay and attempt fast-path optimizations (`EventReplayDispatcher.cs`).

**Event handler implementations:**

* Implemented several event handlers for the different canvas events