### PR TITLE
Enhance selection tool UX and implement quick select feature

### DIFF
--- a/Scribble.Shared/Lib/CanvasElements/CanvasElement.cs
+++ b/Scribble.Shared/Lib/CanvasElements/CanvasElement.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Serialization;
 using Scribble.Shared.Lib.CanvasElements.Strokes;
+using SkiaSharp;
 
 namespace Scribble.Shared.Lib.CanvasElements;
 
@@ -33,4 +34,17 @@ public interface IClonable
     /// Returns a deep copy of this element.
     /// </summary>
     CanvasElement Clone(bool preserveId = false);
+}
+
+public interface ISelectable
+{
+    /// <summary>
+    /// The bounds of the element.
+    /// </summary>
+    public SKRect Bounds { get; }
+
+    /// <summary>
+    /// The rotation of the element in radians.
+    /// </summary>
+    public float Rotation { get; set; }
 }

--- a/Scribble.Shared/Lib/CanvasElements/CanvasImage.cs
+++ b/Scribble.Shared/Lib/CanvasElements/CanvasImage.cs
@@ -3,7 +3,7 @@ using SkiaSharp;
 
 namespace Scribble.Shared.Lib.CanvasElements;
 
-public class CanvasImage : CanvasElement, IClonable
+public class CanvasImage : CanvasElement, IClonable, ISelectable
 {
     public required string ImageBase64String { get; init; }
 

--- a/Scribble.Shared/Lib/CanvasElements/Strokes/DrawStroke.cs
+++ b/Scribble.Shared/Lib/CanvasElements/Strokes/DrawStroke.cs
@@ -33,7 +33,8 @@ public class DrawStroke : PaintableStroke, IClonable
             RawPoints = [..RawPoints],
             StablePath = StablePath != null ? new SKPath(StablePath) : null,
             LayerIndex = LayerIndex,
-            CreatorConnectionId = CreatorConnectionId
+            CreatorConnectionId = CreatorConnectionId,
+            Rotation = Rotation
         };
         return clone;
     }

--- a/Scribble.Shared/Lib/CanvasElements/Strokes/PaintableStroke.cs
+++ b/Scribble.Shared/Lib/CanvasElements/Strokes/PaintableStroke.cs
@@ -1,13 +1,20 @@
+using System.Text.Json.Serialization;
+using Scribble.Shared.Converters;
+using SkiaSharp;
+
 namespace Scribble.Shared.Lib.CanvasElements.Strokes;
 
 /// <summary>
 /// Represents a stroke that has a visual paint and can be erased/selected.
 /// Base class for both DrawStroke and TextStroke.
 /// </summary>
-public abstract class PaintableStroke : Stroke, IClonable
+public abstract class PaintableStroke : Stroke, IClonable, ISelectable
 {
     public bool IsToBeErased = false;
     public required HashSet<ToolOption> ToolOptions { get; init; } = [];
     public required StrokePaint Paint { get; init; } = new();
     public abstract CanvasElement Clone(bool preserveId = false);
+    public SKMatrix TransformMatrix { get; set; } = SKMatrix.Identity;
+    [JsonIgnore] public SKRect Bounds => Path.Bounds;
+    public float Rotation { get; set; }
 }

--- a/Scribble.Shared/Lib/CanvasElements/Strokes/TextStroke.cs
+++ b/Scribble.Shared/Lib/CanvasElements/Strokes/TextStroke.cs
@@ -1,5 +1,4 @@
 using System.Text.Json.Serialization;
-using Scribble.Shared.Converters;
 using SkiaSharp;
 
 namespace Scribble.Shared.Lib.CanvasElements.Strokes;
@@ -20,12 +19,6 @@ public class TextStroke : PaintableStroke, IClonable
     /// This is the anchor used when rebuilding the path after font-size changes.
     /// </summary>
     public required SKPoint Position { get; set; }
-
-    /// <summary>
-    /// Cumulatively tracks translation, rotation, and scaling matrices applied to the stroke.
-    /// </summary>
-    [JsonConverter(typeof(SKMatrixJsonConverter))]
-    public SKMatrix TransformMatrix { get; set; } = SKMatrix.Identity;
 
     /// <summary>
     /// Whether this text stroke is rendered in bold.
@@ -66,7 +59,8 @@ public class TextStroke : PaintableStroke, IClonable
             IsBold = IsBold,
             IsItalic = IsItalic,
             LayerIndex = LayerIndex,
-            CreatorConnectionId = CreatorConnectionId
+            CreatorConnectionId = CreatorConnectionId,
+            Rotation = Rotation
         };
         return clone;
     }

--- a/Scribble.Shared/Lib/Event.cs
+++ b/Scribble.Shared/Lib/Event.cs
@@ -32,6 +32,7 @@ namespace Scribble.Shared.Lib;
 [JsonDerivedType(typeof(UpdateStrokeStyleEvent), typeDiscriminator: "UpdateStrokeStyleEvent")]
 [JsonDerivedType(typeof(UpdateStrokeThicknessEvent), typeDiscriminator: "UpdateStrokeThicknessEvent")]
 [JsonDerivedType(typeof(ClearSelectionEvent), typeDiscriminator: "ClearSelectionEvent")]
+[JsonDerivedType(typeof(SelectByIdsEvent), typeDiscriminator: "SelectByIdsEvent")]
 [JsonDerivedType(typeof(AddImageEvent), typeDiscriminator: "AddImageEvent")]
 [JsonDerivedType(typeof(UpdateTextEvent), typeDiscriminator: "UpdateTextEvent")]
 [JsonDerivedType(typeof(UpdateFontCasingEvent), typeDiscriminator: "UpdateFontCasingEvent")]

--- a/Scribble.Shared/Lib/Events/SelectionEvents.cs
+++ b/Scribble.Shared/Lib/Events/SelectionEvents.cs
@@ -9,3 +9,14 @@ public record IncreaseSelectionBoundEvent(Guid ActionId, Guid BoundId, SKPoint P
 public record EndSelectionEvent(Guid ActionId, Guid BoundId) : Event(ActionId), ITerminalEvent;
 
 public record ClearSelectionEvent(Guid ActionId) : Event(ActionId), ITerminalEvent;
+
+/// <summary>
+/// Selects a specific set of canvas elements by their IDs.
+/// Unlike the other selection events, no spatial containment check is performed,
+/// the targets are taken directly from <see cref="ElementIds"/>.
+/// </summary>
+public record SelectByIdsEvent(
+    Guid ActionId,
+    Guid BoundId,
+    IReadOnlyList<Guid> ElementIds)
+    : Event(ActionId), ITerminalEvent;

--- a/Scribble/Services/CanvasStateService/Handlers/SelectionReplayHandler.cs
+++ b/Scribble/Services/CanvasStateService/Handlers/SelectionReplayHandler.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Scribble.Services.CanvasStateService.State;
 using Scribble.Shared.Lib.CanvasElements;
 using Scribble.Shared.Lib.CanvasElements.Strokes;
@@ -71,20 +72,34 @@ public class SelectionReplayHandler :
 
     public void Replay(ClearSelectionEvent ev, CanvasState ctx)
     {
-        // Mark selection as stale if it has no targets
-        if (ev.CreatorConnectionId == ctx.MyConnectionId && ctx.SelectedElementIds.Count == 0)
+        // Check if there are any selection bounds for this user.
+        // If not, the clear selection action can be marked stale.
+        var hasSelectionBounds =
+            ctx.SelectionBounds.Values.Any(bound => bound.CreatorConnectionId == ev.CreatorConnectionId);
+
+        if (ev.CreatorConnectionId == ctx.MyConnectionId && !hasSelectionBounds)
         {
             ctx.StaleActionIds.Add(ev.ActionId);
         }
 
+        var boundsToRemove = new List<Guid>();
         foreach (var bound in ctx.SelectionBounds.Values)
         {
             if (bound.CreatorConnectionId == ev.CreatorConnectionId)
             {
-                ctx.SelectionBounds.Remove(bound.Id);
-                ctx.ActiveSelectionBoundId = null;
-                ctx.SelectedElementIds.Clear();
+                boundsToRemove.Add(bound.Id);
             }
+        }
+
+        foreach (var boundId in boundsToRemove)
+        {
+            ctx.SelectionBounds.Remove(boundId);
+        }
+
+        if (ctx.MyConnectionId == ev.CreatorConnectionId)
+        {
+            ctx.ActiveSelectionBoundId = null;
+            ctx.SelectedElementIds.Clear();
         }
     }
 

--- a/Scribble/Services/CanvasStateService/Handlers/SelectionReplayHandler.cs
+++ b/Scribble/Services/CanvasStateService/Handlers/SelectionReplayHandler.cs
@@ -12,14 +12,17 @@ namespace Scribble.Services.CanvasStateService.Handlers;
 
 /// <summary>
 /// Handles replay and fast-path for selection-related events:
-/// CreateSelectionBoundEvent, IncreaseSelectionBoundEvent, EndSelectionEvent, ClearSelectionEvent
+/// CreateSelectionBoundEvent, IncreaseSelectionBoundEvent, EndSelectionEvent,
+/// ClearSelectionEvent, SelectByIdsEvent
 /// </summary>
 public class SelectionReplayHandler :
     IEventReplayHandler<CreateSelectionBoundEvent>,
     IEventReplayHandler<IncreaseSelectionBoundEvent>,
     IEventReplayHandler<EndSelectionEvent>,
     IEventReplayHandler<ClearSelectionEvent>,
-    IFastPathHandler<IncreaseSelectionBoundEvent>
+    IEventReplayHandler<SelectByIdsEvent>,
+    IFastPathHandler<IncreaseSelectionBoundEvent>,
+    IFastPathHandler<SelectByIdsEvent>
 {
     // Replay handlers
 
@@ -174,5 +177,79 @@ public class SelectionReplayHandler :
                 }
             }
         }
+    }
+
+    public void Replay(SelectByIdsEvent ev, CanvasState ctx)
+    {
+        ctx.SelectionBounds.Clear();
+
+        var bound = new SelectionBound
+        {
+            Id = ev.BoundId,
+            Path = new SKPath(),
+            CreatorConnectionId = ev.CreatorConnectionId
+        };
+
+        // Only include IDs that still exist on the canvas (guards against undo
+        // having removed an element that was originally in the selection)
+        var validIds = ctx.PaintableStrokes.Keys
+            .Concat(ctx.CanvasImages.Keys)
+            .ToHashSet();
+
+        foreach (var id in ev.ElementIds)
+        {
+            if (validIds.Contains(id))
+            {
+                bound.Targets.Add(id);
+            }
+        }
+
+        // Mark stale if nothing survived, mirrors EndSelectionEvent behaviour
+        if (bound.Targets.Count == 0)
+        {
+            ctx.StaleActionIds.Add(ev.ActionId);
+            return;
+        }
+
+        ctx.SelectionBounds[ev.BoundId] = bound;
+    }
+
+    public bool TryApplyFastPath(SelectByIdsEvent ev, CanvasState ctx)
+    {
+        ctx.SelectionBounds.Clear();
+
+        var bound = new SelectionBound
+        {
+            Id = ev.BoundId,
+            Path = new SKPath(),
+            CreatorConnectionId = ev.CreatorConnectionId
+        };
+
+        var validIds = ctx.ElementsWithLayers.Select(e => e.Id).ToHashSet();
+
+        foreach (var id in ev.ElementIds)
+        {
+            if (validIds.Contains(id))
+            {
+                bound.Targets.Add(id);
+            }
+        }
+
+        if (bound.Targets.Count == 0)
+        {
+            ctx.StaleActionIds.Add(ev.ActionId);
+            return true;
+        }
+
+        ctx.SelectionBounds[ev.BoundId] = bound;
+
+        if (ev.CreatorConnectionId == ctx.MyConnectionId)
+        {
+            ctx.ActiveSelectionBoundId = ev.BoundId;
+            ctx.SelectedElementIds.Clear();
+            ctx.SelectedElementIds.AddRange(bound.Targets);
+        }
+
+        return true;
     }
 }

--- a/Scribble/Services/CanvasStateService/Handlers/TransformReplayHandler.cs
+++ b/Scribble/Services/CanvasStateService/Handlers/TransformReplayHandler.cs
@@ -46,27 +46,24 @@ public class TransformReplayHandler :
     {
         if (ctx.SelectionBounds.TryGetValue(ev.BoundId, out var bound))
         {
+            var rotationMatrix = SKMatrix.CreateRotation(ev.DegreesRad, ev.Center.X, ev.Center.Y);
             foreach (var boundTargetId in bound.Targets)
             {
                 if (ctx.PaintableStrokes.TryGetValue(boundTargetId, out var stroke))
                 {
-                    var matrix = SKMatrix.CreateRotation(ev.DegreesRad, ev.Center.X, ev.Center.Y);
-                    stroke.Path.Transform(matrix);
-                    if (stroke is TextStroke rotatedText)
-                    {
-                        rotatedText.TransformMatrix = rotatedText.TransformMatrix.PostConcat(matrix);
-                    }
+                    stroke.Rotation += ev.DegreesRad;
+                    stroke.Path.Transform(rotationMatrix);
+                    // Keep track of the transformations applied to the stroke
+                    stroke.TransformMatrix = stroke.TransformMatrix.PostConcat(rotationMatrix);
                 }
                 else if (ctx.CanvasImages.TryGetValue(boundTargetId, out var image))
                 {
                     image.Rotation += ev.DegreesRad;
-
                     // Rotate the bounds center around the rotation pivot
                     var imgCenter = new SKPoint(image.Bounds.MidX, image.Bounds.MidY);
-                    var rotated = SKMatrix.CreateRotation(ev.DegreesRad, ev.Center.X, ev.Center.Y)
-                        .MapPoint(imgCenter);
+                    var rotatedPoint = rotationMatrix.MapPoint(imgCenter);
                     var bounds = image.Bounds;
-                    bounds.Offset(rotated.X - imgCenter.X, rotated.Y - imgCenter.Y);
+                    bounds.Offset(rotatedPoint.X - imgCenter.X, rotatedPoint.Y - imgCenter.Y);
                     image.Bounds = bounds;
                 }
             }
@@ -77,21 +74,17 @@ public class TransformReplayHandler :
     {
         if (ctx.SelectionBounds.TryGetValue(ev.BoundId, out var bound))
         {
+            var scaleMatrix = SKMatrix.CreateScale(ev.Scale.X, ev.Scale.Y, ev.Center.X, ev.Center.Y);
             foreach (var boundTargetId in bound.Targets)
             {
                 if (ctx.PaintableStrokes.TryGetValue(boundTargetId, out var stroke))
                 {
-                    var matrix = SKMatrix.CreateScale(ev.Scale.X, ev.Scale.Y, ev.Center.X, ev.Center.Y);
-                    stroke.Path.Transform(matrix);
-                    if (stroke is TextStroke scaledText)
-                    {
-                        scaledText.TransformMatrix = scaledText.TransformMatrix.PostConcat(matrix);
-                    }
+                    stroke.Path.Transform(scaleMatrix);
+                    // Keep track of the transformations applied to the stroke
+                    stroke.TransformMatrix = stroke.TransformMatrix.PostConcat(scaleMatrix);
                 }
                 else if (ctx.CanvasImages.TryGetValue(boundTargetId, out var image))
                 {
-                    var scaleMatrix =
-                        SKMatrix.CreateScale(ev.Scale.X, ev.Scale.Y, ev.Center.X, ev.Center.Y);
                     var topLeft = scaleMatrix.MapPoint(new SKPoint(image.Bounds.Left, image.Bounds.Top));
                     var bottomRight =
                         scaleMatrix.MapPoint(new SKPoint(image.Bounds.Right, image.Bounds.Bottom));
@@ -124,16 +117,14 @@ public class TransformReplayHandler :
     {
         if (ctx.SelectionBounds.TryGetValue(ev.BoundId, out var bound))
         {
+            var translationMatrix = SKMatrix.CreateTranslation(ev.Delta.X, ev.Delta.Y);
             foreach (var boundTargetId in bound.Targets)
             {
                 if (ctx.PaintableStrokes.TryGetValue(boundTargetId, out var stroke))
                 {
-                    var matrix = SKMatrix.CreateTranslation(ev.Delta.X, ev.Delta.Y);
-                    stroke.Path.Transform(matrix);
-                    if (stroke is TextStroke textStroke)
-                    {
-                        textStroke.TransformMatrix = textStroke.TransformMatrix.PostConcat(matrix);
-                    }
+                    stroke.Path.Transform(translationMatrix);
+                    // Keep track of the transformations applied to the stroke
+                    stroke.TransformMatrix = stroke.TransformMatrix.PostConcat(translationMatrix);
                 }
                 else if (ctx.CanvasImages.TryGetValue(boundTargetId, out var image))
                 {
@@ -153,25 +144,21 @@ public class TransformReplayHandler :
     {
         if (ctx.SelectionBounds.TryGetValue(ev.BoundId, out var bound))
         {
+            var rotationMatrix = SKMatrix.CreateRotation(ev.DegreesRad, ev.Center.X, ev.Center.Y);
             foreach (var boundTargetId in bound.Targets)
             {
                 if (ctx.PaintableStrokes.TryGetValue(boundTargetId, out var stroke))
                 {
-                    var matrix = SKMatrix.CreateRotation(ev.DegreesRad, ev.Center.X,
-                        ev.Center.Y);
-                    stroke.Path.Transform(matrix);
-                    if (stroke is TextStroke textStroke)
-                    {
-                        textStroke.TransformMatrix = textStroke.TransformMatrix.PostConcat(matrix);
-                    }
+                    stroke.Rotation += ev.DegreesRad;
+                    stroke.Path.Transform(rotationMatrix);
+                    // Keep track of the transformations applied to the stroke
+                    stroke.TransformMatrix = stroke.TransformMatrix.PostConcat(rotationMatrix);
                 }
                 else if (ctx.CanvasImages.TryGetValue(boundTargetId, out var image))
                 {
                     image.Rotation += ev.DegreesRad;
                     var imgCenter = new SKPoint(image.Bounds.MidX, image.Bounds.MidY);
-                    var rotated = SKMatrix
-                        .CreateRotation(ev.DegreesRad, ev.Center.X, ev.Center.Y)
-                        .MapPoint(imgCenter);
+                    var rotated = rotationMatrix.MapPoint(imgCenter);
                     var bounds = image.Bounds;
                     bounds.Offset(rotated.X - imgCenter.X, rotated.Y - imgCenter.Y);
                     image.Bounds = bounds;
@@ -188,22 +175,18 @@ public class TransformReplayHandler :
     {
         if (ctx.SelectionBounds.TryGetValue(ev.BoundId, out var bound))
         {
+            var scaleMatrix = SKMatrix.CreateScale(ev.Scale.X, ev.Scale.Y, ev.Center.X,
+                ev.Center.Y);
             foreach (var boundTargetId in bound.Targets)
             {
                 if (ctx.PaintableStrokes.TryGetValue(boundTargetId, out var stroke))
                 {
-                    var matrix = SKMatrix.CreateScale(ev.Scale.X, ev.Scale.Y, ev.Center.X,
-                        ev.Center.Y);
-                    stroke.Path.Transform(matrix);
-                    if (stroke is TextStroke textStroke)
-                    {
-                        textStroke.TransformMatrix = textStroke.TransformMatrix.PostConcat(matrix);
-                    }
+                    stroke.Path.Transform(scaleMatrix);
+                    // Keep track of the transformations applied to the stroke
+                    stroke.TransformMatrix = stroke.TransformMatrix.PostConcat(scaleMatrix);
                 }
                 else if (ctx.CanvasImages.TryGetValue(boundTargetId, out var image))
                 {
-                    var scaleMatrix = SKMatrix.CreateScale(ev.Scale.X, ev.Scale.Y,
-                        ev.Center.X, ev.Center.Y);
                     var topLeft = scaleMatrix.MapPoint(new SKPoint(image.Bounds.Left, image.Bounds.Top));
                     var bottomRight =
                         scaleMatrix.MapPoint(new SKPoint(image.Bounds.Right, image.Bounds.Bottom));
@@ -235,19 +218,16 @@ public class TransformReplayHandler :
     /// </summary>
     internal static void MoveElements(IEnumerable<CanvasElement> elements, SKPoint delta)
     {
+        var translationMatrix = SKMatrix.CreateTranslation(delta.X, delta.Y);
         foreach (var canvasElement in elements)
         {
             switch (canvasElement)
             {
                 case PaintableStroke stroke:
                 {
-                    var matrix = SKMatrix.CreateTranslation(delta.X, delta.Y);
-                    stroke.Path.Transform(matrix);
-                    if (stroke is TextStroke movedText)
-                    {
-                        movedText.TransformMatrix = movedText.TransformMatrix.PostConcat(matrix);
-                    }
-
+                    stroke.Path.Transform(translationMatrix);
+                    // Keep track of the transformations applied to the stroke
+                    stroke.TransformMatrix = stroke.TransformMatrix.PostConcat(translationMatrix);
                     break;
                 }
                 case CanvasImage image:

--- a/Scribble/Tools/PointerTools/ArrowTool/ArrowTool.cs
+++ b/Scribble/Tools/PointerTools/ArrowTool/ArrowTool.cs
@@ -29,18 +29,18 @@ public class ArrowTool : StrokeTool
     {
         _strokeId = Guid.NewGuid();
         _actionId = Guid.NewGuid();
-        CanvasState.ApplyEvent(new StartStrokeEvent(_actionId, _strokeId, startPoint, StrokePaint.Clone(),
+        CanvasStateService.ApplyEvent(new StartStrokeEvent(_actionId, _strokeId, startPoint, StrokePaint.Clone(),
             ToolType.Arrow, ToolOptions));
     }
 
     public override void HandlePointerMove(SKPoint prevCoord, SKPoint currentCoord)
     {
-        CanvasState.ApplyEvent(new LineStrokeLineToEvent(_actionId, _strokeId, currentCoord));
+        CanvasStateService.ApplyEvent(new LineStrokeLineToEvent(_actionId, _strokeId, currentCoord));
     }
 
     public override void HandlePointerRelease(SKPoint prevCoord, SKPoint currentCoord)
     {
-        CanvasState.ApplyEvent(new EndStrokeEvent(_actionId));
+        CanvasStateService.ApplyEvent(new EndStrokeEvent(_actionId));
     }
 
     public static (SKPoint, SKPoint) GetArrowHeadPoints(SKPoint start, SKPoint end, float strokeWidth)

--- a/Scribble/Tools/PointerTools/EllipseTool/EllipseTool.cs
+++ b/Scribble/Tools/PointerTools/EllipseTool/EllipseTool.cs
@@ -33,17 +33,17 @@ public class EllipseTool : StrokeTool
     {
         _strokeId = Guid.NewGuid();
         _actionId = Guid.NewGuid();
-        CanvasState.ApplyEvent(new StartStrokeEvent(_actionId, _strokeId, startPoint, StrokePaint.Clone(),
+        CanvasStateService.ApplyEvent(new StartStrokeEvent(_actionId, _strokeId, startPoint, StrokePaint.Clone(),
             ToolType.Ellipse, ToolOptions));
     }
 
     public override void HandlePointerMove(SKPoint prevCoord, SKPoint currentCoord)
     {
-        CanvasState.ApplyEvent(new LineStrokeLineToEvent(_actionId, _strokeId, currentCoord));
+        CanvasStateService.ApplyEvent(new LineStrokeLineToEvent(_actionId, _strokeId, currentCoord));
     }
 
     public override void HandlePointerRelease(SKPoint prevCoord, SKPoint currentCoord)
     {
-        CanvasState.ApplyEvent(new EndStrokeEvent(_actionId));
+        CanvasStateService.ApplyEvent(new EndStrokeEvent(_actionId));
     }
 }

--- a/Scribble/Tools/PointerTools/EraseTool/EraseTool.cs
+++ b/Scribble/Tools/PointerTools/EraseTool/EraseTool.cs
@@ -24,16 +24,16 @@ public class EraseTool : PointerTool
     {
         _strokeId = Guid.NewGuid();
         _actionId = Guid.NewGuid();
-        CanvasState.ApplyEvent(new StartEraseStrokeEvent(_actionId, _strokeId, startPoint));
+        CanvasStateService.ApplyEvent(new StartEraseStrokeEvent(_actionId, _strokeId, startPoint));
     }
 
     public override void HandlePointerMove(SKPoint prevCoord, SKPoint currentCoord)
     {
-        CanvasState.ApplyEvent(new EraseStrokeLineToEvent(_actionId, _strokeId, currentCoord));
+        CanvasStateService.ApplyEvent(new EraseStrokeLineToEvent(_actionId, _strokeId, currentCoord));
     }
 
     public override void HandlePointerRelease(SKPoint prevCoord, SKPoint currentCoord)
     {
-        CanvasState.ApplyEvent(new TriggerEraseEvent(_actionId, _strokeId));
+        CanvasStateService.ApplyEvent(new TriggerEraseEvent(_actionId, _strokeId));
     }
 }

--- a/Scribble/Tools/PointerTools/ImageTool/ImageTool.cs
+++ b/Scribble/Tools/PointerTools/ImageTool/ImageTool.cs
@@ -70,7 +70,7 @@ public class ImageTool : PointerTool
             var actionId = Guid.NewGuid();
             var imageId = Guid.NewGuid();
             var imageSize = ScaleToFit(bitmap.Width, bitmap.Height, MaxImageDimension);
-            CanvasState.ApplyEvent(new AddImageEvent(actionId, imageId, base64String, imageCoord, imageSize));
+            CanvasStateService.ApplyEvent(new AddImageEvent(actionId, imageId, base64String, imageCoord, imageSize));
         });
     }
 

--- a/Scribble/Tools/PointerTools/LineTool/LineTool.cs
+++ b/Scribble/Tools/PointerTools/LineTool/LineTool.cs
@@ -29,17 +29,17 @@ public class LineTool : StrokeTool
     {
         _strokeId = Guid.NewGuid();
         _actionId = Guid.NewGuid();
-        CanvasState.ApplyEvent(new StartStrokeEvent(_actionId, _strokeId, startPoint, StrokePaint.Clone(),
+        CanvasStateService.ApplyEvent(new StartStrokeEvent(_actionId, _strokeId, startPoint, StrokePaint.Clone(),
             ToolType.Line, ToolOptions));
     }
 
     public override void HandlePointerMove(SKPoint prevCoord, SKPoint currentCoord)
     {
-        CanvasState.ApplyEvent(new LineStrokeLineToEvent(_actionId, _strokeId, currentCoord));
+        CanvasStateService.ApplyEvent(new LineStrokeLineToEvent(_actionId, _strokeId, currentCoord));
     }
 
     public override void HandlePointerRelease(SKPoint prevCoord, SKPoint currentCoord)
     {
-        CanvasState.ApplyEvent(new EndStrokeEvent(_actionId));
+        CanvasStateService.ApplyEvent(new EndStrokeEvent(_actionId));
     }
 }

--- a/Scribble/Tools/PointerTools/PencilTool/PencilTool.cs
+++ b/Scribble/Tools/PointerTools/PencilTool/PencilTool.cs
@@ -29,7 +29,7 @@ public class PencilTool : StrokeTool
         _strokeId = Guid.NewGuid();
         _actionId = Guid.NewGuid();
         _lastAcceptedPoint = startPoint;
-        CanvasState.ApplyEvent(
+        CanvasStateService.ApplyEvent(
             new StartStrokeEvent(_actionId, _strokeId, startPoint, StrokePaint.Clone(), ToolType.Pencil, ToolOptions));
     }
 
@@ -42,11 +42,11 @@ public class PencilTool : StrokeTool
         }
 
         _lastAcceptedPoint = currentCoord;
-        CanvasState.ApplyEvent(new PencilStrokeLineToEvent(_actionId, _strokeId, currentCoord));
+        CanvasStateService.ApplyEvent(new PencilStrokeLineToEvent(_actionId, _strokeId, currentCoord));
     }
 
     public override void HandlePointerRelease(SKPoint prevCoord, SKPoint currentCoord)
     {
-        CanvasState.ApplyEvent(new EndStrokeEvent(_actionId));
+        CanvasStateService.ApplyEvent(new EndStrokeEvent(_actionId));
     }
 }

--- a/Scribble/Tools/PointerTools/PointerTool.cs
+++ b/Scribble/Tools/PointerTools/PointerTool.cs
@@ -12,10 +12,10 @@ namespace Scribble.Tools.PointerTools;
 /// </summary>
 /// <param name="name">The name of the tool</param>
 /// <param name="icon">The bitmap representing the tool's icon</param>
-public abstract class PointerTool(string name, ICanvasStateService canvasState, Bitmap icon)
+public abstract class PointerTool(string name, ICanvasStateService canvasStateService, Bitmap icon)
 {
     public string Name { get; } = name;
-    protected ICanvasStateService CanvasState { get; } = canvasState;
+    protected ICanvasStateService CanvasStateService { get; } = canvasStateService;
     public Bitmap ToolIcon { get; } = icon;
     public Cursor? Cursor { get; protected init; }
     public KeyGesture? HotKey { get; protected init; }

--- a/Scribble/Tools/PointerTools/RectangleTool/RectangleTool.cs
+++ b/Scribble/Tools/PointerTools/RectangleTool/RectangleTool.cs
@@ -33,17 +33,17 @@ public class RectangleTool : StrokeTool
     {
         _strokeId = Guid.NewGuid();
         _actionId = Guid.NewGuid();
-        CanvasState.ApplyEvent(new StartStrokeEvent(_actionId, _strokeId, startPoint, StrokePaint.Clone(),
+        CanvasStateService.ApplyEvent(new StartStrokeEvent(_actionId, _strokeId, startPoint, StrokePaint.Clone(),
             ToolType.Rectangle, ToolOptions));
     }
 
     public override void HandlePointerMove(SKPoint prevCoord, SKPoint currentCoord)
     {
-        CanvasState.ApplyEvent(new LineStrokeLineToEvent(_actionId, _strokeId, currentCoord));
+        CanvasStateService.ApplyEvent(new LineStrokeLineToEvent(_actionId, _strokeId, currentCoord));
     }
 
     public override void HandlePointerRelease(SKPoint prevCoord, SKPoint currentCoord)
     {
-        CanvasState.ApplyEvent(new EndStrokeEvent(_actionId));
+        CanvasStateService.ApplyEvent(new EndStrokeEvent(_actionId));
     }
 }

--- a/Scribble/Tools/PointerTools/SelectTool/SelectTool.cs
+++ b/Scribble/Tools/PointerTools/SelectTool/SelectTool.cs
@@ -91,25 +91,27 @@ class SelectTool : PointerTool
     }
 
     /// <summary>
-    /// Selects all elements in the list
+    /// Selects all elements in the list by their IDs.
+    /// Fires a <see cref="SelectByIdsEvent"/> so the handler sets targets directly
+    /// without any spatial containment check.
     /// </summary>
     public void SelectElements(List<ISelectable> elements)
     {
         if (elements.Count == 0) return;
-        var allElementIds = CanvasStateService.CanvasElements.Select(element => element.Id).ToHashSet();
-        var canvasElements = elements.OfType<CanvasElement>().ToList();
-        var elementIds = canvasElements.Select(element => element.Id).ToHashSet();
-        if (allElementIds.IsSupersetOf(elementIds))
-        {
-            var combinedBounds = Utilities.GetElementsBounds(canvasElements);
-            var startPoint = new SKPoint(combinedBounds.Left - 1, combinedBounds.Top - 1);
-            var endPoint = new SKPoint(combinedBounds.Right + 1, combinedBounds.Bottom + 1);
-            var actionId = Guid.NewGuid();
-            var boundId = Guid.NewGuid();
 
-            CanvasStateService.ApplyEvent(new CreateSelectionBoundEvent(actionId, boundId, startPoint));
-            CanvasStateService.ApplyEvent(new IncreaseSelectionBoundEvent(actionId, boundId, endPoint));
-            CanvasStateService.ApplyEvent(new EndSelectionEvent(actionId, boundId));
-        }
+        var allElementIds = CanvasStateService.CanvasElements
+            .Select(e => e.Id)
+            .ToHashSet();
+
+        var elementIds = elements
+            .OfType<CanvasElement>()
+            .Select(e => e.Id)
+            .Where(id => allElementIds.Contains(id))
+            .ToList();
+
+        if (elementIds.Count == 0) return;
+
+        CanvasStateService.ApplyEvent(
+            new SelectByIdsEvent(Guid.NewGuid(), Guid.NewGuid(), elementIds));
     }
 }

--- a/Scribble/Tools/PointerTools/SelectTool/SelectTool.cs
+++ b/Scribble/Tools/PointerTools/SelectTool/SelectTool.cs
@@ -18,7 +18,8 @@ class SelectTool : PointerTool
     private Guid _boundId = Guid.NewGuid();
     private Guid _actionId = Guid.NewGuid();
 
-    public SelectTool(string name, ICanvasStateService canvasState, Canvas canvasContainer) : base(name, canvasState,
+    public SelectTool(string name, ICanvasStateService canvasStateService, Canvas canvasContainer) : base(name,
+        canvasStateService,
         LoadToolBitmap(typeof(SelectTool), "cursor.png"))
     {
         Cursor = Cursor.Default;
@@ -44,13 +45,13 @@ class SelectTool : PointerTool
         _canvasContainer.Children.Add(_selectionBorder);
         _boundId = Guid.NewGuid();
         _actionId = Guid.NewGuid();
-        if (CanvasState.ActiveSelectionBoundId != null)
+        if (CanvasStateService.ActiveSelectionBoundId != null)
         {
-            CanvasState.ClearSelection();
+            CanvasStateService.ClearSelection();
         }
 
         // Events use world-space coordinates
-        CanvasState.ApplyEvent(new CreateSelectionBoundEvent(_actionId, _boundId, coord));
+        CanvasStateService.ApplyEvent(new CreateSelectionBoundEvent(_actionId, _boundId, coord));
     }
 
     public override void HandlePointerMove(SKPoint prevCoord, SKPoint currentCoord)
@@ -67,7 +68,7 @@ class SelectTool : PointerTool
         Canvas.SetTop(_selectionBorder, Math.Min(_startPoint.Y, screenPos.Y));
 
         // Events use world-space coordinates
-        CanvasState.ApplyEvent(new IncreaseSelectionBoundEvent(_actionId, _boundId, currentCoord));
+        CanvasStateService.ApplyEvent(new IncreaseSelectionBoundEvent(_actionId, _boundId, currentCoord));
     }
 
     public override void HandlePointerRelease(SKPoint prevCoord, SKPoint currentCoord)
@@ -76,11 +77,11 @@ class SelectTool : PointerTool
 
         _canvasContainer.Children.Remove(_selectionBorder);
         _selectionBorder = null;
-        CanvasState.ApplyEvent(new EndSelectionEvent(_actionId, _boundId));
+        CanvasStateService.ApplyEvent(new EndSelectionEvent(_actionId, _boundId));
     }
 
     public override void HandleToolSwitchOut()
     {
-        CanvasState.ClearSelection();
+        CanvasStateService.ClearSelection();
     }
 }

--- a/Scribble/Tools/PointerTools/SelectTool/SelectTool.cs
+++ b/Scribble/Tools/PointerTools/SelectTool/SelectTool.cs
@@ -1,12 +1,17 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Media;
 using Scribble.Services.CanvasStateService;
+using Scribble.Shared.Lib.CanvasElements;
 using Scribble.Shared.Lib.Events;
 using Scribble.State;
+using Scribble.Utils;
 using SkiaSharp;
+using ISelectable = Scribble.Shared.Lib.CanvasElements.ISelectable;
 
 namespace Scribble.Tools.PointerTools.SelectTool;
 
@@ -83,5 +88,28 @@ class SelectTool : PointerTool
     public override void HandleToolSwitchOut()
     {
         CanvasStateService.ClearSelection();
+    }
+
+    /// <summary>
+    /// Selects all elements in the list
+    /// </summary>
+    public void SelectElements(List<ISelectable> elements)
+    {
+        if (elements.Count == 0) return;
+        var allElementIds = CanvasStateService.CanvasElements.Select(element => element.Id).ToHashSet();
+        var canvasElements = elements.OfType<CanvasElement>().ToList();
+        var elementIds = canvasElements.Select(element => element.Id).ToHashSet();
+        if (allElementIds.IsSupersetOf(elementIds))
+        {
+            var combinedBounds = Utilities.GetElementsBounds(canvasElements);
+            var startPoint = new SKPoint(combinedBounds.Left - 1, combinedBounds.Top - 1);
+            var endPoint = new SKPoint(combinedBounds.Right + 1, combinedBounds.Bottom + 1);
+            var actionId = Guid.NewGuid();
+            var boundId = Guid.NewGuid();
+
+            CanvasStateService.ApplyEvent(new CreateSelectionBoundEvent(actionId, boundId, startPoint));
+            CanvasStateService.ApplyEvent(new IncreaseSelectionBoundEvent(actionId, boundId, endPoint));
+            CanvasStateService.ApplyEvent(new EndSelectionEvent(actionId, boundId));
+        }
     }
 }

--- a/Scribble/Tools/PointerTools/TextTool/TextTool.cs
+++ b/Scribble/Tools/PointerTools/TextTool/TextTool.cs
@@ -147,7 +147,7 @@ public class TextTool : StrokeTool
         {
             if (_editingStroke != null && _editingStroke.Text != text)
             {
-                CanvasState.ApplyEvent(new UpdateTextEvent(_actionId, _editingStroke.Id, text));
+                CanvasStateService.ApplyEvent(new UpdateTextEvent(_actionId, _editingStroke.Id, text));
             }
             else if (_editingStroke == null)
             {
@@ -157,7 +157,7 @@ public class TextTool : StrokeTool
                 var textboxPos = CameraState.ScreenToWorld(screenPos);
                 textboxPos.Y += StrokePaint.TextSize;
                 var strokeId = Guid.NewGuid();
-                CanvasState.ApplyEvent(new AddTextEvent(_actionId, strokeId, textboxPos, text, StrokePaint.Clone(),
+                CanvasStateService.ApplyEvent(new AddTextEvent(_actionId, strokeId, textboxPos, text, StrokePaint.Clone(),
                     ToolOptions));
             }
         }

--- a/Scribble/Utils/Utilities.cs
+++ b/Scribble/Utils/Utilities.cs
@@ -158,4 +158,22 @@ public static class Utilities
 
         return totalBounds;
     }
+
+    /// <summary>
+    /// Converts degrees to radians
+    /// </summary>
+    /// <returns></returns>
+    public static float DegreesToRadians(float degrees)
+    {
+        return (float)(degrees * Math.PI / 180);
+    }
+
+    /// <summary>
+    /// Converts radians to degrees
+    /// </summary>
+    /// <returns></returns>
+    public static float RadiansToDegrees(float radians)
+    {
+        return (float)(radians * 180 / Math.PI);
+    }
 }

--- a/Scribble/Utils/Utilities.cs
+++ b/Scribble/Utils/Utilities.cs
@@ -122,7 +122,7 @@ public static class Utilities
     }
 
     /// <summary>
-    /// Returns the bounds of the elements
+    /// Returns the combined bounds of the elements
     /// </summary>
     public static SKRect GetElementsBounds(IEnumerable<CanvasElement> elements)
     {

--- a/Scribble/ViewModels/UiStateViewModel.cs
+++ b/Scribble/ViewModels/UiStateViewModel.cs
@@ -26,7 +26,7 @@ public partial class UiStateViewModel : ViewModelBase
     private bool CanZoomIn => ZoomLevel < CameraState.MaxZoom;
     private bool CanZoomOut => ZoomLevel > CameraState.MinZoom;
 
-    public event Action<PointerTool?>? ActiveToolChanged;
+    public event Action<PointerTool?, PointerTool?>? ActiveToolChanged;
     public event Action<double>? CenterZoomRequested;
 
     [ObservableProperty] private Color _backgroundColor;
@@ -78,7 +78,7 @@ public partial class UiStateViewModel : ViewModelBase
     partial void OnActivePointerToolChanged(PointerTool? oldValue, PointerTool? newValue)
     {
         oldValue?.HandleToolSwitchOut();
-        ActiveToolChanged?.Invoke(newValue);
+        ActiveToolChanged?.Invoke(oldValue, newValue);
         newValue?.HandleToolSwitchIn();
     }
 

--- a/Scribble/ViewModels/UiStateViewModel.cs
+++ b/Scribble/ViewModels/UiStateViewModel.cs
@@ -184,7 +184,7 @@ public partial class UiStateViewModel : ViewModelBase
         ToolOptionsVisible = ActiveToolOptions.Count > 0;
     }
 
-    public void ShowSelectedCanvasElementOptions(List<CanvasElement> selectedElements)
+    public void ShowSelectedCanvasElementOptions(List<ISelectable> selectedElements)
     {
         var filteredStrokeIds = new Dictionary<ToolOption, List<Guid>>();
         foreach (var element in selectedElements)

--- a/Scribble/Views/MainView.axaml
+++ b/Scribble/Views/MainView.axaml
@@ -49,6 +49,9 @@
                 VerticalAlignment="Stretch"
                 Focusable="True">
 
+            <!-- COVERS ALL CANVAS ELEMENTS, TRIGGERS QUICK SELECTION -->
+            <Canvas Name="QuickSelectionBorders"></Canvas>
+
             <!-- COVERS SELECTED ELEMENTS -->
             <StackPanel Name="SelectionOverlay" Spacing="6" IsVisible="False">
                 <Border Name="SelectionRotationBtn" CornerRadius="100" BorderThickness="2" BorderBrush="Gray"

--- a/Scribble/Views/MainView.axaml
+++ b/Scribble/Views/MainView.axaml
@@ -49,6 +49,9 @@
                 VerticalAlignment="Stretch"
                 Focusable="True">
 
+            <!-- COVERS TEXT STROKES, TRIGGERS EDIT MODE -->
+            <Canvas Name="TextStrokeEditBorders"></Canvas>
+
             <!-- COVERS ALL CANVAS ELEMENTS, TRIGGERS QUICK SELECTION -->
             <Canvas Name="QuickSelectionBorders"></Canvas>
 
@@ -94,8 +97,7 @@
                 </Grid>
             </StackPanel>
 
-            <!-- COVERS TEXT STROKES, TRIGGERS EDIT MODE -->
-            <Canvas Name="TextStrokeEditBorders"></Canvas>
+
             <Canvas.Styles>
                 <Style Selector="TextBox:focus /template/ Border">
                     <Setter Property="BorderBrush" Value="Gray" />

--- a/Scribble/Views/MainView.axaml.cs
+++ b/Scribble/Views/MainView.axaml.cs
@@ -300,7 +300,15 @@ public partial class MainView : UserControl
             // Prevent MarkCanvasElementsForSelection from destroying this border
             // while SelectElements triggers canvas invalidation events
             _quickSelectMoveActive = true;
-            selectTool?.SelectElements([selectableElement]);
+            if ((e.KeyModifiers & KeyModifiers.Shift) != 0)
+            {
+                var currentlySelectedElements = _canvasStateService.GetSelectedElements().Cast<ISelectable>().ToList();
+                selectTool?.SelectElements([..currentlySelectedElements, selectableElement]);
+            }
+            else
+            {
+                selectTool?.SelectElements([selectableElement]);
+            }
 
             // Initialize move state so the user can immediately drag to move
             // without needing a second click on the selection overlay
@@ -835,9 +843,7 @@ public partial class MainView : UserControl
     private void QuickSelectBorderReleased(object? sender, PointerReleasedEventArgs e)
     {
         _quickSelectMoveActive = false;
-
-        SelectionBorder_OnPointerReleased(sender, e);
-
+        _selection.SelectionMoveCoord = SKPoint.Empty;
         // Rebuild the quick-select borders now that the gesture is complete,
         // since we skipped reconstruction during the drag
         MarkCanvasElementsForSelection();

--- a/Scribble/Views/MainView.axaml.cs
+++ b/Scribble/Views/MainView.axaml.cs
@@ -34,6 +34,7 @@ using Scribble.Tools.PointerTools.TextTool;
 using Scribble.Utils;
 using Scribble.ViewModels;
 using SkiaSharp;
+using ISelectable = Scribble.Shared.Lib.CanvasElements.ISelectable;
 
 namespace Scribble.Views;
 
@@ -359,89 +360,174 @@ public partial class MainView : UserControl
     {
         if (_viewModel == null) return;
 
-        var hasEvents = _canvasStateService.CanvasEvents.Count > 0;
-        // Am I triggering a selection?
-        var triggeringSelectionAction = hasEvents &&
-                                        _canvasStateService.CanvasEvents.Last() is EndSelectionEvent es &&
-                                        _canvasStateService.IsLocalSelection(es.BoundId);
-        var allSelectedIds = _canvasStateService.SelectedElementIds;
+        var events = _canvasStateService.CanvasEvents;
+        var userIsSelecting = events.Count > 0
+                              && events.Last() is EndSelectionEvent es
+                              && _canvasStateService.IsLocalSelection(es.BoundId);
+        var selectedElementIds = _canvasStateService.SelectedElementIds;
 
-        if (allSelectedIds.Count > 0)
+        if (selectedElementIds.Count == 0)
         {
-            var selectedStrokes = _viewModel.CanvasElements
-                .Where(element => allSelectedIds.Contains(element.Id) && element is PaintableStroke)
-                .Cast<PaintableStroke>()
-                .ToList();
-            var selectedImages = _viewModel.CanvasElements
-                .Where(element => allSelectedIds.Contains(element.Id) && element is CanvasImage)
-                .Cast<CanvasImage>()
-                .ToList();
-            if (selectedStrokes.Count == 0 && selectedImages.Count == 0)
+            ClearSelectionOverlay(userIsSelecting);
+            return;
+        }
+
+        var selectedElements = _viewModel.CanvasElements
+            .Where(element => selectedElementIds.Contains(element.Id) && element is ISelectable)
+            .Cast<ISelectable>()
+            .ToList();
+
+        var (combinedBounds, rotationAngleDegrees, rotationCenter) =
+            ComputeSelectionGeometry(selectedElements);
+
+        ApplySelectionOverlay(selectedElements, combinedBounds, rotationAngleDegrees, rotationCenter);
+
+        if (userIsSelecting)
+        {
+            _viewModel.UiStateViewModel.ShowSelectedCanvasElementOptions([..selectedElements]);
+        }
+    }
+
+    /// <summary>
+    /// Computes the world-space bounding rect, rotation angle (degrees), and rotation
+    /// center for the given set of selected elements. For a single rotated element the
+    /// bounds are un-rotated so the overlay rectangle matches the element's original shape.
+    /// </summary>
+    private static (SKRect Bounds, float RotationDegrees, SKPoint RotationCenter)
+        ComputeSelectionGeometry(IReadOnlyList<ISelectable> selectedElements)
+    {
+        if (selectedElements.Count == 1)
+        {
+            return ComputeSingleElementGeometry(selectedElements[0]);
+        }
+
+        return ComputeMultiElementGeometry(selectedElements);
+    }
+
+    private static (SKRect Bounds, float RotationDegrees, SKPoint RotationCenter)
+        ComputeSingleElementGeometry(ISelectable element)
+    {
+        var rotationDegrees = Utilities.RadiansToDegrees(element.Rotation);
+        var elementIsRotated = Math.Abs(rotationDegrees) > 0.001f;
+
+        if (!elementIsRotated)
+        {
+            var bounds = element.Bounds;
+            return (bounds, 0f, new SKPoint(bounds.MidX, bounds.MidY));
+        }
+
+        switch (element)
+        {
+            case PaintableStroke stroke:
             {
-                SelectionOverlay.IsVisible = false;
-                return;
+                // Un-rotate the path to recover the axis-aligned bounding box
+                var center = new SKPoint(stroke.Bounds.MidX, stroke.Bounds.MidY);
+                var inverseRotation = SKMatrix.CreateRotationDegrees(-rotationDegrees, center.X, center.Y);
+                var clonedPath = stroke.Path.Clone();
+                clonedPath.Transform(inverseRotation);
+                return (clonedPath.Bounds, rotationDegrees, center);
             }
-
-            SKRect combinedBounds = SKRect.Empty;
-
-            foreach (var strokeBounds in selectedStrokes.Select(stroke => stroke.Path.Bounds))
+            case CanvasImage image:
             {
-                if (combinedBounds == SKRect.Empty)
-                {
-                    combinedBounds = strokeBounds;
-                }
-                else
-                {
-                    combinedBounds.Union(strokeBounds);
-                }
+                // Image bounds are rotation-independent; just record the center
+                var center = new SKPoint(image.Bounds.MidX, image.Bounds.MidY);
+                return (image.Bounds, rotationDegrees, center);
             }
+            default:
+                return (element.Bounds, 0f, new SKPoint(element.Bounds.MidX, element.Bounds.MidY));
+        }
+    }
 
-            foreach (var imageBounds in selectedImages.Select(canvasImage => canvasImage.Bounds))
+    private static (SKRect Bounds, float RotationDegrees, SKPoint RotationCenter)
+        ComputeMultiElementGeometry(IEnumerable<ISelectable> elements)
+    {
+        var combinedBounds = SKRect.Empty;
+        foreach (var bounds in elements.Select(e => e.Bounds))
+        {
+            if (combinedBounds == SKRect.Empty)
             {
-                if (combinedBounds == SKRect.Empty)
-                {
-                    combinedBounds = imageBounds;
-                }
-                else
-                {
-                    combinedBounds.Union(imageBounds);
-                }
+                combinedBounds = bounds;
             }
-
-            // Align the selection overlay with what it has selected
-            // Convert the world-space bounding rect corners to screen-space
-            var topLeftScreen = CameraState.WorldToScreen(new SKPoint(combinedBounds.Left, combinedBounds.Top));
-            var bottomRightScreen = CameraState.WorldToScreen(new SKPoint(combinedBounds.Right, combinedBounds.Bottom));
-            var screenWidth = bottomRightScreen.X - topLeftScreen.X;
-            var screenHeight = bottomRightScreen.Y - topLeftScreen.Y;
-
-            Canvas.SetLeft(SelectionOverlay, topLeftScreen.X);
-            Canvas.SetTop(SelectionOverlay, topLeftScreen.Y - 15 - 6); // rotation handle offset
-            SelectionBoxContainer.Width = screenWidth;
-            SelectionBoxContainer.Height = screenHeight;
-
-            SelectionOverlay.IsVisible = true;
-            _selection.SelectionBounds = combinedBounds;
-            bool isRotating = !double.IsNaN(_selection.SelectionRotationAngle);
-            bool isScaling = _selection.ActiveScaleHandle != null;
-            if (isRotating || isScaling)
+            else
             {
-                SelectionOverlay.IsVisible = false;
+                combinedBounds.Union(bounds);
             }
+        }
 
-            if (triggeringSelectionAction)
-            {
-                _viewModel.UiStateViewModel.ShowSelectedCanvasElementOptions([..selectedStrokes, ..selectedImages]);
-            }
+        // Multi-element selections are never rotated as a group
+        return (combinedBounds, 0f, SKPoint.Empty);
+    }
+
+    /// <summary>
+    /// Positions the selection overlay on screen, applies a rotation transform when a
+    /// single element is rotated, and hides the overlay while a rotate/scale gesture
+    /// is in progress.
+    /// </summary>
+    private void ApplySelectionOverlay(
+        List<ISelectable> selectedElements,
+        SKRect worldBounds,
+        float rotationAngleDegrees,
+        SKPoint worldRotationCenter)
+    {
+        // The rotation handle sits above the selection box (15 px width/height + 6 px gap)
+        const float rotationHandleOffset = 15 + 6;
+
+        // Convert world-space corners to screen-space
+        var topLeftScreen = CameraState.WorldToScreen(new SKPoint(worldBounds.Left, worldBounds.Top));
+        var bottomRightScreen = CameraState.WorldToScreen(new SKPoint(worldBounds.Right, worldBounds.Bottom));
+        var screenWidth = bottomRightScreen.X - topLeftScreen.X;
+        var screenHeight = bottomRightScreen.Y - topLeftScreen.Y;
+
+        Canvas.SetLeft(SelectionOverlay, topLeftScreen.X);
+        Canvas.SetTop(SelectionOverlay, topLeftScreen.Y - rotationHandleOffset);
+        SelectionBoxContainer.Width = screenWidth;
+        SelectionBoxContainer.Height = screenHeight;
+
+        var elementIsRotated = Math.Abs(rotationAngleDegrees) > 0.001f;
+        // Apply or clear rotation transform
+        if (selectedElements.Count == 1 && elementIsRotated)
+        {
+            var overlayLeft = topLeftScreen.X;
+            var overlayTop = topLeftScreen.Y - rotationHandleOffset;
+            var rotationCenterScreen = CameraState.WorldToScreen(worldRotationCenter);
+
+            // Express the rotation center in overlay-local coordinates
+            var localCenterX = rotationCenterScreen.X - overlayLeft;
+            var localCenterY = rotationCenterScreen.Y - overlayTop;
+            var overlayHeight = screenHeight + rotationHandleOffset;
+
+            SelectionOverlay.RenderTransformOrigin = new RelativePoint(
+                localCenterX / screenWidth,
+                localCenterY / overlayHeight,
+                RelativeUnit.Relative);
+            SelectionOverlay.RenderTransform = new RotateTransform(rotationAngleDegrees);
         }
         else
         {
-            SelectionOverlay.IsVisible = false;
-            _selection.SelectionBounds = SKRect.Empty;
-            if (triggeringSelectionAction)
-            {
-                _viewModel.UiStateViewModel.ClearToolOptions();
-            }
+            SelectionOverlay.RenderTransform = null;
+        }
+
+        _selection.SelectionBounds = worldBounds;
+
+        // Hide the overlay while a rotate or scale gesture is in progress so the
+        // handles don't fight with the pointer tracking
+        var gestureInProgress = !double.IsNaN(_selection.SelectionRotationAngle)
+                                || _selection.ActiveScaleHandle != null;
+        SelectionOverlay.IsVisible = !gestureInProgress;
+    }
+
+    /// <summary>
+    /// Hides the selection overlay and optionally resets tool options when
+    /// the hide was caused by a completed selection action that found nothing.
+    /// </summary>
+    private void ClearSelectionOverlay(bool userIsSelecting)
+    {
+        SelectionOverlay.IsVisible = false;
+        _selection.SelectionBounds = SKRect.Empty;
+
+        if (userIsSelecting)
+        {
+            _viewModel?.UiStateViewModel.ClearToolOptions();
         }
     }
 

--- a/Scribble/Views/MainView.axaml.cs
+++ b/Scribble/Views/MainView.axaml.cs
@@ -49,6 +49,7 @@ public partial class MainView : UserControl
     private readonly IDialogService _dialogService;
     private readonly IFileService _fileService;
     private readonly Selection _selection;
+    private bool _quickSelectMoveActive;
 
     public MainView()
     {
@@ -88,6 +89,7 @@ public partial class MainView : UserControl
             _viewModel = viewModel;
             _viewModel.RequestRefreshSelection += VisualizeSelection;
             _viewModel.RequestInvalidateSkiaCanvas += MainCanvas.InvalidateVisual;
+            _viewModel.RequestInvalidateSkiaCanvas += MarkCanvasElementsForSelection;
             _viewModel.RequestInvalidateSkiaCanvas += MarkTextStrokesForEditing;
             _viewModel.UiStateViewModel.CenterZoomRequested += OnCenterZoomRequested;
             _viewModel.UiStateViewModel.ActiveToolChanged += OnActiveToolChanged;
@@ -183,6 +185,127 @@ public partial class MainView : UserControl
     }
 
     /// <summary>
+    /// Put an invisible Border control on all canvas elements that allows quick selection.
+    /// Repositions existing borders when the element set is unchanged (e.g. pan/zoom/move),
+    /// and only does a full rebuild when elements are added or removed.
+    /// </summary>
+    private void MarkCanvasElementsForSelection()
+    {
+        // Don't rebuild the quick-select borders while a quick-select-initiated
+        // move is in progress. Destroying the pressed border would break the
+        // implicit pointer capture and kill PointerMoved/PointerReleased delivery.
+        if (_quickSelectMoveActive) return;
+
+        var selectableElements = _canvasStateService.CanvasElements.OfType<ISelectable>().ToList();
+
+        if (QuickSelectBorderSetMatches(selectableElements))
+        {
+            RepositionQuickSelectBorders(selectableElements);
+        }
+        else
+        {
+            RebuildQuickSelectBorders(selectableElements);
+        }
+    }
+
+    /// <summary>
+    /// Returns true when the existing quick borders correspond 1-to-1 (by element Id)
+    /// to <paramref name="elements"/>, meaning only a reposition is needed.
+    /// </summary>
+    private bool QuickSelectBorderSetMatches(List<ISelectable> elements)
+    {
+        var children = QuickSelectionBorders.Children;
+        if (children.Count != elements.Count) return false;
+
+        for (var i = 0; i < elements.Count; i++)
+        {
+            if (children[i] is not Border { Tag: CanvasElement existingEl } ||
+                elements[i] is not CanvasElement newEl ||
+                existingEl.Id != newEl.Id)
+                return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Cheap path: updates only the position and size of existing quick select borders without
+    /// touching the visual tree structure or allocating new objects.
+    /// </summary>
+    private void RepositionQuickSelectBorders(List<ISelectable> elements)
+    {
+        var children = QuickSelectionBorders.Children;
+        for (var i = 0; i < elements.Count; i++)
+        {
+            var border = (Border)children[i];
+            var bounds = elements[i].Bounds;
+            var topLeftScreenPos = CameraState.WorldToScreen(new SKPoint(bounds.Left, bounds.Top));
+            var bottomRightScreenPos = CameraState.WorldToScreen(new SKPoint(bounds.Right, bounds.Bottom));
+
+            border.Width = bottomRightScreenPos.X - topLeftScreenPos.X;
+            border.Height = bottomRightScreenPos.Y - topLeftScreenPos.Y;
+            // Refresh Tag in case the element object was changed
+            border.Tag = elements[i];
+            Canvas.SetLeft(border, topLeftScreenPos.X);
+            Canvas.SetTop(border, topLeftScreenPos.Y);
+        }
+    }
+
+    /// <summary>
+    /// Clears and recreates all borders. Only called when the set of
+    /// selectable elements has changed (elements added or removed).
+    /// </summary>
+    private void RebuildQuickSelectBorders(List<ISelectable> elements)
+    {
+        QuickSelectionBorders.Children.Clear();
+
+        var quickSelectBorders = new List<Border>(elements.Count);
+        foreach (var element in elements)
+        {
+            var bounds = element.Bounds;
+            var topLeftScreenPos = CameraState.WorldToScreen(new SKPoint(bounds.Left, bounds.Top));
+            var bottomRightScreenPos = CameraState.WorldToScreen(new SKPoint(bounds.Right, bounds.Bottom));
+
+            var border = new Border
+            {
+                Background = Brushes.Transparent,
+                Width = bottomRightScreenPos.X - topLeftScreenPos.X,
+                Height = bottomRightScreenPos.Y - topLeftScreenPos.Y,
+                Tag = element
+            };
+            border.PointerPressed += QuickSelectBorderPressed;
+            border.PointerMoved += SelectionBorder_OnPointerMoved;
+            border.PointerReleased += QuickSelectBorderReleased;
+            Canvas.SetLeft(border, topLeftScreenPos.X);
+            Canvas.SetTop(border, topLeftScreenPos.Y);
+            quickSelectBorders.Add(border);
+        }
+
+        QuickSelectionBorders.Children.AddRange(quickSelectBorders);
+    }
+
+    private void QuickSelectBorderPressed(object? sender, PointerPressedEventArgs e)
+    {
+        // Select the linked ISelectable element
+        if (sender is Border { Tag: ISelectable selectableElement })
+        {
+            var selectTool = _viewModel?.UiStateViewModel.AvailableTools.OfType<SelectTool>().FirstOrDefault();
+            // Prevent MarkCanvasElementsForSelection from destroying this border
+            // while SelectElements triggers canvas invalidation events
+            _quickSelectMoveActive = true;
+            selectTool?.SelectElements([selectableElement]);
+
+            // Initialize move state so the user can immediately drag to move
+            // without needing a second click on the selection overlay
+            if (e.Properties.IsLeftButtonPressed)
+            {
+                _selection.SelectionMoveCoord = GetPointerPosition(e);
+                _selection.MoveActionId = Guid.NewGuid();
+            }
+        }
+    }
+
+    /// <summary>
     /// Identify all text strokes and put an invisible Border control on them that triggers
     /// a pop-up for editing the text
     /// </summary>
@@ -206,23 +329,23 @@ public partial class MainView : UserControl
             var strokeBounds = textStroke.Path.Bounds;
 
             // Convert world-space bounds to screen-space for overlay positioning
-            var topLeftScreen = CameraState.WorldToScreen(new SKPoint(strokeBounds.Left, strokeBounds.Top));
-            var bottomRightScreen =
+            var topLeftScreenPos = CameraState.WorldToScreen(new SKPoint(strokeBounds.Left, strokeBounds.Top));
+            var bottomRightScreenPos =
                 CameraState.WorldToScreen(new SKPoint(strokeBounds.Right, strokeBounds.Bottom));
 
             var border = new Border
             {
                 Background = Brushes.Transparent,
-                Width = bottomRightScreen.X - topLeftScreen.X,
-                Height = bottomRightScreen.Y - topLeftScreen.Y,
+                Width = bottomRightScreenPos.X - topLeftScreenPos.X,
+                Height = bottomRightScreenPos.Y - topLeftScreenPos.Y,
                 Cursor = new Cursor(StandardCursorType.Ibeam),
                 Tag = textStroke
             };
 
             border.DoubleTapped += TextStrokeBorder_OnDoubleTapped;
 
-            Canvas.SetLeft(border, topLeftScreen.X);
-            Canvas.SetTop(border, topLeftScreen.Y);
+            Canvas.SetLeft(border, topLeftScreenPos.X);
+            Canvas.SetTop(border, topLeftScreenPos.Y);
             borders.Add(border);
         }
 
@@ -300,8 +423,9 @@ public partial class MainView : UserControl
         // Re-visualize selection if there was any before zooming, this is needed to correct the size of the selection
         // border post-zoom
         VisualizeSelection();
-        // Re-apply text edit overlay so it stays in sync with the zoom level
+        // Re-apply text edit overlay and quick-select borders so it stays in sync with the zoom level
         MarkTextStrokesForEditing();
+        MarkCanvasElementsForSelection();
     }
 
     private void ZoomToFitBtn_OnClick(object? sender, RoutedEventArgs e)
@@ -372,7 +496,7 @@ public partial class MainView : UserControl
             return;
         }
 
-        var selectedElements = _viewModel.CanvasElements
+        var selectedElements = _canvasStateService.CanvasElements
             .Where(element => selectedElementIds.Contains(element.Id) && element is ISelectable)
             .Cast<ISelectable>()
             .ToList();
@@ -441,18 +565,7 @@ public partial class MainView : UserControl
     private static (SKRect Bounds, float RotationDegrees, SKPoint RotationCenter)
         ComputeMultiElementGeometry(IEnumerable<ISelectable> elements)
     {
-        var combinedBounds = SKRect.Empty;
-        foreach (var bounds in elements.Select(e => e.Bounds))
-        {
-            if (combinedBounds == SKRect.Empty)
-            {
-                combinedBounds = bounds;
-            }
-            else
-            {
-                combinedBounds.Union(bounds);
-            }
-        }
+        var combinedBounds = Utilities.GetElementsBounds(elements.Cast<CanvasElement>().ToList());
 
         // Multi-element selections are never rotated as a group
         return (combinedBounds, 0f, SKPoint.Empty);
@@ -595,10 +708,12 @@ public partial class MainView : UserControl
 
         _prevCoord = pointerCoordinates;
 
-        // Re-apply text edit overlay if canvas is being panned around
+        // Re-apply text edit overlay and quick-select borders if canvas is being panned around
         if (_activePointerTool is PanningTool)
         {
+            VisualizeSelection();
             MarkTextStrokesForEditing();
+            MarkCanvasElementsForSelection();
         }
     }
 
@@ -663,6 +778,8 @@ public partial class MainView : UserControl
         }
 
         VisualizeSelection();
+        MarkTextStrokesForEditing();
+        MarkCanvasElementsForSelection();
         e.Handled = true;
     }
 
@@ -695,6 +812,17 @@ public partial class MainView : UserControl
         }
 
         _selection.SelectionMoveCoord = pointerCoordinates;
+    }
+
+    private void QuickSelectBorderReleased(object? sender, PointerReleasedEventArgs e)
+    {
+        _quickSelectMoveActive = false;
+
+        SelectionBorder_OnPointerReleased(sender, e);
+
+        // Rebuild the quick-select borders now that the gesture is complete,
+        // since we skipped reconstruction during the drag
+        MarkCanvasElementsForSelection();
     }
 
     private void SelectionBorder_OnPointerReleased(object? sender, PointerReleasedEventArgs e)

--- a/Scribble/Views/MainView.axaml.cs
+++ b/Scribble/Views/MainView.axaml.cs
@@ -219,7 +219,7 @@ public partial class MainView : UserControl
                 Tag = textStroke
             };
 
-            border.PointerPressed += TextStrokeBorder_OnPointerPressed;
+            border.DoubleTapped += TextStrokeBorder_OnDoubleTapped;
 
             Canvas.SetLeft(border, topLeftScreen.X);
             Canvas.SetTop(border, topLeftScreen.Y);
@@ -229,9 +229,9 @@ public partial class MainView : UserControl
         TextStrokeEditBorders.Children.AddRange(borders);
     }
 
-    private void TextStrokeBorder_OnPointerPressed(object? sender, PointerPressedEventArgs e)
+    private void TextStrokeBorder_OnDoubleTapped(object? sender, TappedEventArgs e)
     {
-        if (e.Properties.IsLeftButtonPressed && sender is Border { Tag: TextStroke textStroke })
+        if (sender is Border { Tag: TextStroke textStroke })
         {
             var textTool = _viewModel?.UiStateViewModel.AvailableTools.OfType<TextTool>().FirstOrDefault();
             textTool?.StartEditing(textStroke);

--- a/Scribble/Views/MainView.axaml.cs
+++ b/Scribble/Views/MainView.axaml.cs
@@ -196,6 +196,13 @@ public partial class MainView : UserControl
         // implicit pointer capture and kill PointerMoved/PointerReleased delivery.
         if (_quickSelectMoveActive) return;
 
+        // Quick-select borders are only relevant when the Select Tool is active.
+        if (_activePointerTool is not SelectTool)
+        {
+            QuickSelectionBorders.Children.Clear();
+            return;
+        }
+
         var selectableElements = _canvasStateService.CanvasElements.OfType<ISelectable>().ToList();
 
         if (QuickSelectBorderSetMatches(selectableElements))
@@ -362,10 +369,21 @@ public partial class MainView : UserControl
     }
 
     // If the active tool is a stroke tool, show its options else clear and hide the tool options UI
-    private void OnActiveToolChanged(PointerTool? tool)
+    private void OnActiveToolChanged(PointerTool? formerTool, PointerTool? currentTool)
     {
-        _activePointerTool = tool;
-        if (tool == null) return;
+        _activePointerTool = currentTool;
+        if (currentTool == null) return;
+
+        // Update quick-select borders immediately on tool switch, rather than
+        // waiting for the next canvas invalidation.
+        if (formerTool is SelectTool)
+        {
+            QuickSelectionBorders.Children.Clear();
+        }
+        else if (currentTool is SelectTool)
+        {
+            MarkCanvasElementsForSelection();
+        }
 
         if (_activePointerTool is StrokeTool strokeTool)
         {
@@ -376,9 +394,9 @@ public partial class MainView : UserControl
             _viewModel?.UiStateViewModel.ClearToolOptions();
         }
 
-        if (tool.Cursor != null)
+        if (currentTool.Cursor != null)
         {
-            MainCanvas.Cursor = tool.Cursor;
+            MainCanvas.Cursor = currentTool.Cursor;
         }
     }
 

--- a/Scribble/Views/MainView.axaml.cs
+++ b/Scribble/Views/MainView.axaml.cs
@@ -349,7 +349,7 @@ public partial class MainView : UserControl
                 Tag = textStroke
             };
 
-            border.DoubleTapped += TextStrokeBorder_OnDoubleTapped;
+            border.PointerPressed += TextStrokeBorder_OnPointerPressed;
 
             Canvas.SetLeft(border, topLeftScreenPos.X);
             Canvas.SetTop(border, topLeftScreenPos.Y);
@@ -359,7 +359,7 @@ public partial class MainView : UserControl
         TextStrokeEditBorders.Children.AddRange(borders);
     }
 
-    private void TextStrokeBorder_OnDoubleTapped(object? sender, TappedEventArgs e)
+    private void TextStrokeBorder_OnPointerPressed(object? sender, PointerPressedEventArgs e)
     {
         if (sender is Border { Tag: TextStroke textStroke })
         {


### PR DESCRIPTION
This pull request introduces a new selection mechanism that allows canvas elements to be selected directly by their IDs, and refactors selection and transformation logic to improve consistency, extensibility, and maintainability. It also introduces a new `ISelectable` interface for canvas elements and ensures that transformations (move, scale, rotate) consistently update both the visual and logical state of elements.

**Selection system improvements:**

* Added the `SelectByIdsEvent` event and related logic, allowing direct selection of canvas elements by their IDs without spatial checks. This includes full replay and fast-path support in `SelectionReplayHandler`, and registration of the event for serialization.
* Improved `ClearSelectionEvent` handling to better track and clear selection bounds, preventing stale state.

**Canvas element extensibility and consistency:**

* Introduced the `ISelectable` interface, which standardizes `Bounds` and `Rotation` properties for selectable elements. Updated `CanvasImage` and `PaintableStroke` (and thus `DrawStroke` and `TextStroke`) to implement this interface.
* Refactored transformation logic (move, scale, rotate) in `TransformReplayHandler` to always update both the element’s geometry and its logical transformation matrix, ensuring the `Rotation` property is kept in sync.
* Updated cloning logic for strokes to ensure the `Rotation` property is copied.

**Codebase cleanup:**

* Removed redundant `TransformMatrix` property from `TextStroke` (now inherited from `PaintableStroke`).
* Added missing `using SkiaSharp;` directives where needed.

This PR closes #106 
